### PR TITLE
Uses protobuf names for serde field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ controlling and monitoring power grid devices over a message bus.
 The OpenFMB specification is defined in UML and converted to potentially 
 any number of message encodings. The most common is protocol buffers.
 
-The UML generates additional information to describe an single-inheritance
+The UML generates additional information to describe a single-inheritance
 message type hierarchy that cannot be directly expressed in a proto or
 correctly code generated for using protoc and Rusts prost alone.
 

--- a/openfmb-messages/build.rs
+++ b/openfmb-messages/build.rs
@@ -24,7 +24,6 @@ fn main() {
     const OUT: &str = "src";
     openfmb_codegen::Config::new()
         .btree_map(&["."])
-        .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
         .out_dir(OUT)
         .compile_protos(&PROTOS, &INCLUDES)
         .unwrap();

--- a/openfmb-messages/src/breakermodule.rs
+++ b/openfmb-messages/src/breakermodule.rs
@@ -1,7 +1,6 @@
 use crate::commonmodule::*;
 /// Reclose enabled
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct BreakerDiscreteControlXcbr {
     /// UML inherited base object
     // parent_message: true
@@ -11,6 +10,7 @@ pub struct BreakerDiscreteControlXcbr {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "discreteControlXCBR")]
     pub discrete_control_xcbr: ::std::option::Option<super::commonmodule::DiscreteControlXcbr>,
 }
 mod breaker_discrete_control_xcbr {
@@ -78,8 +78,7 @@ impl IsIdentifiedObject for BreakerDiscreteControlXcbr {
     }
 }
 /// Breaker discrete control class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct BreakerDiscreteControl {
     /// UML inherited base object
     // parent_message: true
@@ -89,12 +88,15 @@ pub struct BreakerDiscreteControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlValue")]
     pub control_value: ::std::option::Option<super::commonmodule::ControlValue>,
     /// IEC61850 enhanced control parameters.
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub check: ::std::option::Option<super::commonmodule::CheckConditions>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "breakerDiscreteControlXCBR")]
     pub breaker_discrete_control_xcbr: ::std::option::Option<BreakerDiscreteControlXcbr>,
 }
 mod breaker_discrete_control {
@@ -162,8 +164,7 @@ impl IsIdentifiedObject for BreakerDiscreteControl {
 /// A mechanical switching device capable of making, carrying, and breaking currents under normal
 /// circuit conditions and also making, carrying for a specified time, and breaking currents under
 /// specified abnormal circuit conditions e.g.  those of short circuit.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Breaker {
     /// UML inherited base object
     // parent_message: true
@@ -173,6 +174,7 @@ pub struct Breaker {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipment")]
     pub conducting_equipment: ::std::option::Option<super::commonmodule::ConductingEquipment>,
 }
 mod breaker {
@@ -225,8 +227,7 @@ impl IsNamedObject for Breaker {
 }
 /// Instructs an end device (or an end device group) to perform a specified action.
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct BreakerDiscreteControlProfile {
     /// UML inherited base object
     // parent_message: true
@@ -236,6 +237,7 @@ pub struct BreakerDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -245,6 +247,7 @@ pub struct BreakerDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub breaker: ::std::option::Option<Breaker>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -254,6 +257,7 @@ pub struct BreakerDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "breakerDiscreteControl")]
     pub breaker_discrete_control: ::std::option::Option<BreakerDiscreteControl>,
 }
 mod breaker_discrete_control_profile {
@@ -327,8 +331,7 @@ impl IsIdentifiedObject for BreakerDiscreteControlProfile {
     }
 }
 /// Breaker event class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct BreakerEvent {
     /// UML inherited base object
     // parent_message: true
@@ -338,9 +341,11 @@ pub struct BreakerEvent {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventValue")]
     pub event_value: ::std::option::Option<super::commonmodule::EventValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "statusAndEventXCBR")]
     pub status_and_event_xcbr: ::std::option::Option<super::commonmodule::StatusAndEventXcbr>,
 }
 mod breaker_event {
@@ -400,8 +405,7 @@ impl IsIdentifiedObject for BreakerEvent {
 }
 /// Breaker event profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct BreakerEventProfile {
     /// UML inherited base object
     // parent_message: true
@@ -411,6 +415,7 @@ pub struct BreakerEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventMessageInfo")]
     pub event_message_info: ::std::option::Option<super::commonmodule::EventMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -420,6 +425,7 @@ pub struct BreakerEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub breaker: ::std::option::Option<Breaker>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -429,6 +435,7 @@ pub struct BreakerEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "breakerEvent")]
     pub breaker_event: ::std::option::Option<BreakerEvent>,
 }
 mod breaker_event_profile {
@@ -502,8 +509,7 @@ impl IsIdentifiedObject for BreakerEventProfile {
     }
 }
 /// MISSING DOCUMENTATION!!!
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct BreakerReading {
     /// UML inherited base object
     // parent_message: true
@@ -513,18 +519,23 @@ pub struct BreakerReading {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipmentTerminalReading")]
     pub conducting_equipment_terminal_reading: ::std::option::Option<super::commonmodule::ConductingEquipmentTerminalReading>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "diffReadingMMXU")]
     pub diff_reading_mmxu: ::std::option::Option<super::commonmodule::ReadingMmxu>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "phaseMMTN")]
     pub phase_mmtn: ::std::option::Option<super::commonmodule::PhaseMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "readingMMTR")]
     pub reading_mmtr: ::std::option::Option<super::commonmodule::ReadingMmtr>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "readingMMXU")]
     pub reading_mmxu: ::std::option::Option<super::commonmodule::ReadingMmxu>,
 }
 mod breaker_reading {
@@ -597,8 +608,7 @@ impl IsConductingEquipmentTerminalReading for BreakerReading {
 }
 /// Breaker reading profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct BreakerReadingProfile {
     /// UML inherited base object
     // parent_message: true
@@ -608,6 +618,7 @@ pub struct BreakerReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "readingMessageInfo")]
     pub reading_message_info: ::std::option::Option<super::commonmodule::ReadingMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -617,6 +628,7 @@ pub struct BreakerReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub breaker: ::std::option::Option<Breaker>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -626,6 +638,7 @@ pub struct BreakerReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="3")]
+    #[serde(default, rename = "breakerReading")]
     pub breaker_reading: ::std::vec::Vec<BreakerReading>,
 }
 mod breaker_reading_profile {
@@ -698,8 +711,7 @@ impl IsIdentifiedObject for BreakerReadingProfile {
     }
 }
 /// Status of a breaker
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct BreakerStatus {
     /// UML inherited base object
     // parent_message: true
@@ -709,9 +721,11 @@ pub struct BreakerStatus {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusValue")]
     pub status_value: ::std::option::Option<super::commonmodule::StatusValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "statusAndEventXCBR")]
     pub status_and_event_xcbr: ::std::option::Option<super::commonmodule::StatusAndEventXcbr>,
 }
 mod breaker_status {
@@ -771,8 +785,7 @@ impl IsIdentifiedObject for BreakerStatus {
 }
 /// Breaker status profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct BreakerStatusProfile {
     /// UML inherited base object
     // parent_message: true
@@ -782,6 +795,7 @@ pub struct BreakerStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusMessageInfo")]
     pub status_message_info: ::std::option::Option<super::commonmodule::StatusMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -791,6 +805,7 @@ pub struct BreakerStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub breaker: ::std::option::Option<Breaker>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -800,6 +815,7 @@ pub struct BreakerStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "breakerStatus")]
     pub breaker_status: ::std::option::Option<BreakerStatus>,
 }
 mod breaker_status_profile {

--- a/openfmb-messages/src/capbankmodule.rs
+++ b/openfmb-messages/src/capbankmodule.rs
@@ -1,7 +1,6 @@
 use crate::commonmodule::*;
 /// Cap bank compensator system
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankSystem {
     /// UML inherited base object
     // parent_message: true
@@ -11,6 +10,7 @@ pub struct CapBankSystem {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipment")]
     pub conducting_equipment: ::std::option::Option<super::commonmodule::ConductingEquipment>,
 }
 mod cap_bank_system {
@@ -62,11 +62,11 @@ impl IsNamedObject for CapBankSystem {
     }
 }
 /// LN: Power cap bank  Name: YPSH
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankControlYpsh {
     /// (controllable) Position of the switch of power shunt.
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "Pos")]
     pub pos: ::std::option::Option<super::commonmodule::PhaseDpc>,
 }
 mod cap_bank_control_ypsh {
@@ -96,11 +96,11 @@ impl IsCapBankControlYpsh for CapBankControlYpsh {
     }
 }
 /// Point definition (Point)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankPoint {
     /// Regulator control
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub control: ::std::option::Option<CapBankControlYpsh>,
     /// Start time
     // parent_message: false
@@ -110,6 +110,7 @@ pub struct CapBankPoint {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "startTime")]
     pub start_time: ::std::option::Option<super::commonmodule::Timestamp>,
 }
 mod cap_bank_point {
@@ -146,8 +147,7 @@ impl IsCapBankPoint for CapBankPoint {
     }
 }
 /// Curve shape setting (FC=SP) (CSG_SP)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankCsg {
     /// The array with the points specifying a curve shape.
     // parent_message: false
@@ -157,6 +157,7 @@ pub struct CapBankCsg {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="1")]
+    #[serde(default, rename = "crvPts")]
     pub crv_pts: ::std::vec::Vec<CapBankPoint>,
 }
 mod cap_bank_csg {
@@ -185,8 +186,7 @@ impl IsCapBankCsg for CapBankCsg {
     }
 }
 /// OpenFMB specialization for control schedule using:  LN: Schedule   Name: FSCH
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankControlScheduleFsch {
     /// Control value in CSG type
     // parent_message: false
@@ -196,6 +196,7 @@ pub struct CapBankControlScheduleFsch {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "ValCSG")]
     pub val_csg: ::std::option::Option<CapBankCsg>,
 }
 mod cap_bank_control_schedule_fsch {
@@ -225,8 +226,7 @@ impl IsCapBankControlScheduleFsch for CapBankControlScheduleFsch {
     }
 }
 /// Using 61850 FSCC for cap bank control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankControlFscc {
     /// UML inherited base object
     // parent_message: true
@@ -236,9 +236,11 @@ pub struct CapBankControlFscc {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlFSCC")]
     pub control_fscc: ::std::option::Option<super::commonmodule::ControlFscc>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "capBankControlScheduleFSCH")]
     pub cap_bank_control_schedule_fsch: ::std::option::Option<CapBankControlScheduleFsch>,
 }
 mod cap_bank_control_fscc {
@@ -313,8 +315,7 @@ impl IsIdentifiedObject for CapBankControlFscc {
     }
 }
 /// CapBank control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankControl {
     /// UML inherited base object
     // parent_message: true
@@ -324,12 +325,15 @@ pub struct CapBankControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlValue")]
     pub control_value: ::std::option::Option<super::commonmodule::ControlValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub check: ::std::option::Option<super::commonmodule::CheckConditions>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "capBankControlFSCC")]
     pub cap_bank_control_fscc: ::std::option::Option<CapBankControlFscc>,
 }
 mod cap_bank_control {
@@ -397,8 +401,7 @@ impl IsIdentifiedObject for CapBankControl {
 /// Cap bank control profile.  Instructs an end device (or an end device group) to perform a
 /// specified action.
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankControlProfile {
     /// UML inherited base object
     // parent_message: true
@@ -408,6 +411,7 @@ pub struct CapBankControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -417,6 +421,7 @@ pub struct CapBankControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "capBankControl")]
     pub cap_bank_control: ::std::option::Option<CapBankControl>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -426,6 +431,7 @@ pub struct CapBankControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "capBankSystem")]
     pub cap_bank_system: ::std::option::Option<CapBankSystem>,
 }
 mod cap_bank_control_profile {
@@ -499,8 +505,7 @@ impl IsIdentifiedObject for CapBankControlProfile {
     }
 }
 /// OpenFMB specialization for cap bank discrete control:
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankDiscreteControlYpsh {
     /// UML inherited base object
     // parent_message: true
@@ -510,9 +515,11 @@ pub struct CapBankDiscreteControlYpsh {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForControl")]
     pub logical_node_for_control: ::std::option::Option<super::commonmodule::LogicalNodeForControl>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "Pos")]
     pub pos: ::std::option::Option<super::commonmodule::PhaseDpc>,
 }
 mod cap_bank_discrete_control_ypsh {
@@ -579,8 +586,7 @@ impl IsIdentifiedObject for CapBankDiscreteControlYpsh {
     }
 }
 /// Cap bank discrete control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankDiscreteControl {
     /// UML inherited base object
     // parent_message: true
@@ -590,12 +596,15 @@ pub struct CapBankDiscreteControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlValue")]
     pub control_value: ::std::option::Option<super::commonmodule::ControlValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub check: ::std::option::Option<super::commonmodule::CheckConditions>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "capBankDiscreteControlYPSH")]
     pub cap_bank_discrete_control_ypsh: ::std::option::Option<CapBankDiscreteControlYpsh>,
 }
 mod cap_bank_discrete_control {
@@ -663,8 +672,7 @@ impl IsIdentifiedObject for CapBankDiscreteControl {
 /// Cap bank discrete control profile.  Instructs an end device (or an end device group) to perform
 /// a specified action.
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankDiscreteControlProfile {
     /// UML inherited base object
     // parent_message: true
@@ -674,6 +682,7 @@ pub struct CapBankDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -683,6 +692,7 @@ pub struct CapBankDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "capBankControl")]
     pub cap_bank_control: ::std::option::Option<CapBankDiscreteControl>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -692,6 +702,7 @@ pub struct CapBankDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "capBankSystem")]
     pub cap_bank_system: ::std::option::Option<CapBankSystem>,
 }
 mod cap_bank_discrete_control_profile {
@@ -765,8 +776,7 @@ impl IsIdentifiedObject for CapBankDiscreteControlProfile {
     }
 }
 /// LN: Power cap bank  Name: YPSH
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankEventAndStatusYpsh {
     /// UML inherited base object
     // parent_message: true
@@ -776,12 +786,15 @@ pub struct CapBankEventAndStatusYpsh {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForEventAndStatus")]
     pub logical_node_for_event_and_status: ::std::option::Option<super::commonmodule::LogicalNodeForEventAndStatus>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "DynamicTest")]
     pub dynamic_test: ::std::option::Option<super::commonmodule::EnsDynamicTestKind>,
     /// (controllable) Position of the switch of power shunt.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "Pos")]
     pub pos: ::std::option::Option<super::commonmodule::PhaseDps>,
 }
 mod cap_bank_event_and_status_ypsh {
@@ -855,8 +868,7 @@ impl IsIdentifiedObject for CapBankEventAndStatusYpsh {
     }
 }
 /// Cap bank event
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankEvent {
     /// UML inherited base object
     // parent_message: true
@@ -866,9 +878,11 @@ pub struct CapBankEvent {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventValue")]
     pub event_value: ::std::option::Option<super::commonmodule::EventValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "CapBankEventAndStatusYPSH")]
     pub cap_bank_event_and_status_ypsh: ::std::option::Option<CapBankEventAndStatusYpsh>,
 }
 mod cap_bank_event {
@@ -928,8 +942,7 @@ impl IsIdentifiedObject for CapBankEvent {
 }
 /// Cap bank status profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankEventProfile {
     /// UML inherited base object
     // parent_message: true
@@ -939,6 +952,7 @@ pub struct CapBankEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventMessageInfo")]
     pub event_message_info: ::std::option::Option<super::commonmodule::EventMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -948,6 +962,7 @@ pub struct CapBankEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "capBankEvent")]
     pub cap_bank_event: ::std::option::Option<CapBankEvent>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -957,6 +972,7 @@ pub struct CapBankEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "capBankSystem")]
     pub cap_bank_system: ::std::option::Option<CapBankSystem>,
 }
 mod cap_bank_event_profile {
@@ -1030,8 +1046,7 @@ impl IsIdentifiedObject for CapBankEventProfile {
     }
 }
 /// Cap bank reading value
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankReading {
     /// UML inherited base object
     // parent_message: true
@@ -1041,15 +1056,19 @@ pub struct CapBankReading {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipmentTerminalReading")]
     pub conducting_equipment_terminal_reading: ::std::option::Option<super::commonmodule::ConductingEquipmentTerminalReading>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phaseMMTN")]
     pub phase_mmtn: ::std::option::Option<super::commonmodule::PhaseMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "readingMMTR")]
     pub reading_mmtr: ::std::option::Option<super::commonmodule::ReadingMmtr>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "readingMMXU")]
     pub reading_mmxu: ::std::option::Option<super::commonmodule::ReadingMmxu>,
 }
 mod cap_bank_reading {
@@ -1115,8 +1134,7 @@ impl IsConductingEquipmentTerminalReading for CapBankReading {
 }
 /// Cap bank reading profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankReadingProfile {
     /// UML inherited base object
     // parent_message: true
@@ -1126,6 +1144,7 @@ pub struct CapBankReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "readingMessageInfo")]
     pub reading_message_info: ::std::option::Option<super::commonmodule::ReadingMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1135,6 +1154,7 @@ pub struct CapBankReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "capBankReading")]
     pub cap_bank_reading: ::std::option::Option<CapBankReading>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1144,6 +1164,7 @@ pub struct CapBankReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "capBankSystem")]
     pub cap_bank_system: ::std::option::Option<CapBankSystem>,
 }
 mod cap_bank_reading_profile {
@@ -1217,8 +1238,7 @@ impl IsIdentifiedObject for CapBankReadingProfile {
     }
 }
 /// Cap bank status
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankStatus {
     /// UML inherited base object
     // parent_message: true
@@ -1228,9 +1248,11 @@ pub struct CapBankStatus {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusValue")]
     pub status_value: ::std::option::Option<super::commonmodule::StatusValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "capBankEventAndStatusYPSH")]
     pub cap_bank_event_and_status_ypsh: ::std::option::Option<CapBankEventAndStatusYpsh>,
 }
 mod cap_bank_status {
@@ -1290,8 +1312,7 @@ impl IsIdentifiedObject for CapBankStatus {
 }
 /// Cap bank status profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapBankStatusProfile {
     /// UML inherited base object
     // parent_message: true
@@ -1301,6 +1322,7 @@ pub struct CapBankStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusMessageInfo")]
     pub status_message_info: ::std::option::Option<super::commonmodule::StatusMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1310,6 +1332,7 @@ pub struct CapBankStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "capBankStatus")]
     pub cap_bank_status: ::std::option::Option<CapBankStatus>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1319,6 +1342,7 @@ pub struct CapBankStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "capBankSystem")]
     pub cap_bank_system: ::std::option::Option<CapBankSystem>,
 }
 mod cap_bank_status_profile {

--- a/openfmb-messages/src/commonmodule.rs
+++ b/openfmb-messages/src/commonmodule.rs
@@ -1,7 +1,7 @@
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalFaultDirectionKind {
     #[prost(enumeration="FaultDirectionKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_fault_direction_kind {
@@ -29,10 +29,10 @@ impl IsOptionalFaultDirectionKind for OptionalFaultDirectionKind {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalPhaseFaultDirectionKind {
     #[prost(enumeration="PhaseFaultDirectionKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_phase_fault_direction_kind {
@@ -61,8 +61,7 @@ impl IsOptionalPhaseFaultDirectionKind for OptionalPhaseFaultDirectionKind {
     }
 }
 /// Directional protection indication information (ACD)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Acd {
     /// General direction of the fault. If the faults of individual phases have different directions,
     /// this attribute shall be set to 'dirGeneral'='both'.
@@ -73,18 +72,23 @@ pub struct Acd {
     // uuid: false
     // key: false
     #[prost(enumeration="FaultDirectionKind", tag="1")]
+    #[serde(default, rename = "dirGeneral")]
     pub dir_general: i32,
     /// Direction of the fault for earth current.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "dirNeut")]
     pub dir_neut: ::std::option::Option<OptionalPhaseFaultDirectionKind>,
     /// Direction of the fault for phase A.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "dirPhsA")]
     pub dir_phs_a: ::std::option::Option<OptionalPhaseFaultDirectionKind>,
     /// Direction of the fault for phase B.
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "dirPhsB")]
     pub dir_phs_b: ::std::option::Option<OptionalPhaseFaultDirectionKind>,
     /// Direction of the fault for phase C.
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "dirPhsC")]
     pub dir_phs_c: ::std::option::Option<OptionalPhaseFaultDirectionKind>,
     /// General indication of a protection activation (e.g. by the fault). Depending on the function,
     /// 'general' may or may not be resulting from the phase attributes (phsA', 'phsB', 'phsC', 'neut').
@@ -95,18 +99,23 @@ pub struct Acd {
     // uuid: false
     // key: false
     #[prost(bool, tag="6")]
+    #[serde(default)]
     pub general: bool,
     /// See 'ACT.neut'.
     #[prost(message, optional, tag="7")]
+    #[serde(default)]
     pub neut: ::std::option::Option<bool>,
     /// Value true indicates a trip or a start event of phase A.
     #[prost(message, optional, tag="8")]
+    #[serde(default, rename = "phsA")]
     pub phs_a: ::std::option::Option<bool>,
     /// Value true indicates a trip or a start event of phase B.
     #[prost(message, optional, tag="9")]
+    #[serde(default, rename = "phsB")]
     pub phs_b: ::std::option::Option<bool>,
     /// Value true indicates a trip or a start event of phase C.
     #[prost(message, optional, tag="10")]
+    #[serde(default, rename = "phsC")]
     pub phs_c: ::std::option::Option<bool>,
 }
 mod acd {
@@ -198,11 +207,11 @@ impl IsAcd for Acd {
 }
 /// This is a root class to provide common identification for all classes needing identification and
 /// naming attributes.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct IdentifiedObject {
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub description: ::std::option::Option<::std::string::String>,
     /// Master resource identifier issued by a model authority. The mRID must semantically be a UUID as
     /// specified in RFC 4122. The mRID is globally unique.
@@ -213,9 +222,11 @@ pub struct IdentifiedObject {
     // uuid: true
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "mRID")]
     pub m_rid: ::std::option::Option<::std::string::String>,
     /// The name is any free human readable and possibly non unique text naming the object.
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub name: ::std::option::Option<::std::string::String>,
 }
 mod identified_object {
@@ -260,8 +271,7 @@ impl IsIdentifiedObject for IdentifiedObject {
 }
 /// An electrical connection point (AC or DC) to a piece of conducting equipment. Terminals are
 /// connected at physical connection points called connectivity nodes.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct AcdcTerminal {
     /// UML inherited base object
     // parent_message: true
@@ -271,6 +281,7 @@ pub struct AcdcTerminal {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<IdentifiedObject>,
     /// The connected status is related to a bus-branch model and the topological node to terminal
     /// relation.  True implies the terminal is connected to the related topological node and false implies
@@ -280,11 +291,13 @@ pub struct AcdcTerminal {
     /// particular for an AC line segment, where the reactive line charging can be significant, this is a
     /// relevant case.
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub connected: ::std::option::Option<bool>,
     /// The orientation of the terminal connections for a multiple terminal conducting equipment.  The
     /// sequence numbering starts with 1 and additional terminals should follow in increasing order.   The
     /// first terminal is the "starting point" for a two terminal branch.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "sequenceNumber")]
     pub sequence_number: ::std::option::Option<i32>,
 }
 mod acdc_terminal {
@@ -341,10 +354,10 @@ impl IsIdentifiedObject for AcdcTerminal {
         self.parent_mut()
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalUnitSymbolKind {
     #[prost(enumeration="UnitSymbolKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_unit_symbol_kind {
@@ -372,10 +385,10 @@ impl IsOptionalUnitSymbolKind for OptionalUnitSymbolKind {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalUnitMultiplierKind {
     #[prost(enumeration="UnitMultiplierKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_unit_multiplier_kind {
@@ -404,17 +417,19 @@ impl IsOptionalUnitMultiplierKind for OptionalUnitMultiplierKind {
     }
 }
 /// MISSING DOCUMENTATION!!!
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ActivePower {
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub multiplier: ::std::option::Option<OptionalUnitMultiplierKind>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub unit: ::std::option::Option<OptionalUnitSymbolKind>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub value: ::std::option::Option<f32>,
 }
 mod active_power {
@@ -457,10 +472,10 @@ impl IsActivePower for ActivePower {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalPhaseCodeKind {
     #[prost(enumeration="PhaseCodeKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_phase_code_kind {
@@ -489,11 +504,11 @@ impl IsOptionalPhaseCodeKind for OptionalPhaseCodeKind {
     }
 }
 /// Unit definition (Unit)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Unit {
     /// (default='') Unit multiplier.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub multiplier: ::std::option::Option<OptionalUnitMultiplierKind>,
     /// SI unit of measure.
     // parent_message: false
@@ -503,6 +518,7 @@ pub struct Unit {
     // uuid: false
     // key: false
     #[prost(enumeration="UnitSymbolKind", tag="2")]
+    #[serde(default, rename = "SIUnit")]
     pub si_unit: i32,
 }
 mod unit {
@@ -537,10 +553,10 @@ impl IsUnit for Unit {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalValidityKind {
     #[prost(enumeration="ValidityKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_validity_kind {
@@ -569,8 +585,7 @@ impl IsOptionalValidityKind for OptionalValidityKind {
     }
 }
 /// Describes some reasons in case 'validity' is not 'good'.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct DetailQual {
     /// (default=false) If true, the value may not be a correct value due to a reference being out of
     /// calibration. The server shall decide if validity shall be set to invalid or questionable (used for
@@ -582,6 +597,7 @@ pub struct DetailQual {
     // uuid: false
     // key: false
     #[prost(bool, tag="1")]
+    #[serde(default, rename = "badReference")]
     pub bad_reference: bool,
     /// (default=false) If true, a supervision function has detected an internal or external failure.
     // parent_message: false
@@ -591,6 +607,7 @@ pub struct DetailQual {
     // uuid: false
     // key: false
     #[prost(bool, tag="2")]
+    #[serde(default)]
     pub failure: bool,
     /// (default=false) If true, the value does not meet the stated accuracy of the source. EXAMPLE The
     /// measured value of power factor may be noisy (inaccurate) when the current is very small.
@@ -601,6 +618,7 @@ pub struct DetailQual {
     // uuid: false
     // key: false
     #[prost(bool, tag="3")]
+    #[serde(default)]
     pub inaccurate: bool,
     /// (default=false) If true, an evaluation function has detected an inconsistency.
     // parent_message: false
@@ -610,6 +628,7 @@ pub struct DetailQual {
     // uuid: false
     // key: false
     #[prost(bool, tag="4")]
+    #[serde(default)]
     pub inconsistent: bool,
     /// (default=false) If true, an update is not made during a specific time interval. The value may be
     /// an old value that may have changed in the meantime. This specific time interval may be defined by an
@@ -622,6 +641,7 @@ pub struct DetailQual {
     // uuid: false
     // key: false
     #[prost(bool, tag="5")]
+    #[serde(default, rename = "oldData")]
     pub old_data: bool,
     /// (default=false) To prevent overloading of event driven communication channels, it is desirable
     /// to detect and suppress oscillating (fast changing) binary inputs. If a signal changes in a defined
@@ -641,6 +661,7 @@ pub struct DetailQual {
     // uuid: false
     // key: false
     #[prost(bool, tag="6")]
+    #[serde(default)]
     pub oscillatory: bool,
     /// (default=false) If true, the attribute to which the quality has been associated is beyond a
     /// predefined range of values. The server shall decide if validity shall be set to invalid or
@@ -655,6 +676,7 @@ pub struct DetailQual {
     // uuid: false
     // key: false
     #[prost(bool, tag="7")]
+    #[serde(default, rename = "outOfRange")]
     pub out_of_range: bool,
     /// (default=false) If true, the value of the attribute to which the quality has been associated is
     /// beyond the capability of being represented properly (used for measurand information only). EXAMPLE A
@@ -667,6 +689,7 @@ pub struct DetailQual {
     // uuid: false
     // key: false
     #[prost(bool, tag="8")]
+    #[serde(default)]
     pub overflow: bool,
 }
 mod detail_qual {
@@ -736,10 +759,10 @@ impl IsDetailQual for DetailQual {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalSourceKind {
     #[prost(enumeration="SourceKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_source_kind {
@@ -772,8 +795,7 @@ impl IsOptionalSourceKind for OptionalSourceKind {
 /// different quality attributes are <i>not</i> independent.The default value shall be applied if the
 /// functionality of the related attribute is not supported. The mapping may specify to exclude the
 /// attribute from the message if it is not supported or if the default value applies.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Quality {
     /// Describes some reasons in case 'validity' is not 'good'.
     // parent_message: false
@@ -783,6 +805,7 @@ pub struct Quality {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "detailQual")]
     pub detail_qual: ::std::option::Option<DetailQual>,
     /// (default=false) If true, further update of the value has been blocked by an operator. The value
     /// shall be the information that was acquired before blocking. If this flag is set, then the
@@ -798,6 +821,7 @@ pub struct Quality {
     // uuid: false
     // key: false
     #[prost(bool, tag="2")]
+    #[serde(default, rename = "operatorBlocked")]
     pub operator_blocked: bool,
     /// (default=process) Defines the source of a value. NOTE 1 Substitution may be done locally or via
     /// the communication services. In the second case, specific attributes with a FC=SV are used. NOTE 2
@@ -811,6 +835,7 @@ pub struct Quality {
     // uuid: false
     // key: false
     #[prost(enumeration="SourceKind", tag="3")]
+    #[serde(default)]
     pub source: i32,
     /// (default=false) If true, the value is a test value. The processing of the test quality in the
     /// client shall be as described in IEC 61850-7-4. This bit shall be completely independent from the
@@ -822,6 +847,7 @@ pub struct Quality {
     // uuid: false
     // key: false
     #[prost(bool, tag="4")]
+    #[serde(default)]
     pub test: bool,
     /// Validity of the value, as condensed information for the client. In case this value is not
     /// 'good', some reasons may be found in the 'detailQual'.
@@ -832,6 +858,7 @@ pub struct Quality {
     // uuid: false
     // key: false
     #[prost(enumeration="ValidityKind", tag="5")]
+    #[serde(default)]
     pub validity: i32,
 }
 mod quality {
@@ -884,10 +911,10 @@ impl IsQuality for Quality {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalTimeAccuracyKind {
     #[prost(enumeration="TimeAccuracyKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_time_accuracy_kind {
@@ -916,8 +943,7 @@ impl IsOptionalTimeAccuracyKind for OptionalTimeAccuracyKind {
     }
 }
 /// Information about the quality of the time source of the sending IED.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct TimeQuality {
     /// If true, the time source of the sending device is unreliable and the value of the time stamp
     /// shall be ignored.
@@ -928,6 +954,7 @@ pub struct TimeQuality {
     // uuid: false
     // key: false
     #[prost(bool, tag="1")]
+    #[serde(default, rename = "clockFailure")]
     pub clock_failure: bool,
     /// If true, the time source of the sending device is not synchronised with the external UTC time.
     // parent_message: false
@@ -937,6 +964,7 @@ pub struct TimeQuality {
     // uuid: false
     // key: false
     #[prost(bool, tag="2")]
+    #[serde(default, rename = "clockNotSynchronized")]
     pub clock_not_synchronized: bool,
     /// If true, the value in 'P_Timestamp.SecondSinceEpoch' contains all leap seconds occurred.
     /// Otherwise, it does not take into account the leap seconds that occurred before the initialization of
@@ -950,6 +978,7 @@ pub struct TimeQuality {
     // uuid: false
     // key: false
     #[prost(bool, tag="3")]
+    #[serde(default, rename = "leapSecondsKnown")]
     pub leap_seconds_known: bool,
     /// Information about the quality of the time source of the sending IED.
     // parent_message: false
@@ -959,6 +988,7 @@ pub struct TimeQuality {
     // uuid: false
     // key: false
     #[prost(enumeration="TimeAccuracyKind", tag="4")]
+    #[serde(default, rename = "timeAccuracy")]
     pub time_accuracy: i32,
 }
 mod time_quality {
@@ -1008,8 +1038,7 @@ impl IsTimeQuality for TimeQuality {
 /// SCSMs.The NULL time stamp has all fields set to 0 (zero).The relation between a timestamp value, the
 /// synchronization of an internal time with an external time source (for example, UTC time), and other
 /// information related to time model are available as requirements in Clause 21.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Timestamp {
     /// Second since epoch (1970-01-01T00:00:00Z)
     // parent_message: false
@@ -1019,9 +1048,11 @@ pub struct Timestamp {
     // uuid: false
     // key: false
     #[prost(uint64, tag="2")]
+    #[serde(default)]
     pub seconds: u64,
     /// IEC61850 time quality
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub tq: ::std::option::Option<TimeQuality>,
     /// Partial (sub) second expressed in nanoseconds (10<sup>-9</sup> second).
     // parent_message: false
@@ -1031,6 +1062,7 @@ pub struct Timestamp {
     // uuid: false
     // key: false
     #[prost(uint32, tag="4")]
+    #[serde(default)]
     pub nanoseconds: u32,
 }
 mod timestamp {
@@ -1072,8 +1104,7 @@ impl IsTimestamp for Timestamp {
     }
 }
 /// Measured value (MV)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Mv {
     /// Value of the magnitude based on a deadband calculation from the instantaneous value 'instMag'.
     /// The value of 'mag' shall be updated to the current instantaneous value 'instMag' when the value has
@@ -1088,16 +1119,20 @@ pub struct Mv {
     // uuid: false
     // key: false
     #[prost(double, tag="1")]
+    #[serde(default)]
     pub mag: f64,
     /// Quality of the values in 'instMag', 'mag', 'range'.
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub q: ::std::option::Option<Quality>,
     /// Timestamp of the last refresh of the value in 'mag' or of the last change of the value in any of
     /// 'range' or 'q'.
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub t: ::std::option::Option<Timestamp>,
     /// Unit for: 'instMag', 'mag', 'subMag', 'rangeC'.
     #[prost(message, optional, tag="4")]
+    #[serde(default)]
     pub units: ::std::option::Option<Unit>,
 }
 mod mv {
@@ -1147,8 +1182,7 @@ impl IsMv for Mv {
     }
 }
 /// IEC61850 logical node.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LogicalNode {
     /// UML inherited base object
     // parent_message: true
@@ -1158,6 +1192,7 @@ pub struct LogicalNode {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<IdentifiedObject>,
 }
 mod logical_node {
@@ -1201,8 +1236,7 @@ impl IsIdentifiedObject for LogicalNode {
     }
 }
 /// LN: Generic process I/O   Name: GGIO
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct AnalogEventAndStatusGgio {
     /// UML inherited base object
     // parent_message: true
@@ -1212,6 +1246,7 @@ pub struct AnalogEventAndStatusGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNode")]
     pub logical_node: ::std::option::Option<LogicalNode>,
     /// Generic analogue input <i>n</i>.
     // parent_message: false
@@ -1221,9 +1256,11 @@ pub struct AnalogEventAndStatusGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "AnIn")]
     pub an_in: ::std::option::Option<Mv>,
     /// Phase code
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "Phase")]
     pub phase: ::std::option::Option<OptionalPhaseCodeKind>,
 }
 mod analog_event_and_status_ggio {
@@ -1291,14 +1328,15 @@ impl IsIdentifiedObject for AnalogEventAndStatusGgio {
 /// This is a root class similar to IdentifiedObject but without the mRID. The reason to separate
 /// the two classes is because the mRID may need to be defined as a separate key field for technology
 /// such as the DDS implementation.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct NamedObject {
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub description: ::std::option::Option<::std::string::String>,
     /// The name is any free human readable and possibly non unique text naming the object.
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub name: ::std::option::Option<::std::string::String>,
 }
 mod named_object {
@@ -1335,8 +1373,7 @@ impl IsNamedObject for NamedObject {
     }
 }
 /// The parts of a power system that are physical devices, electronic or mechanical.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ApplicationSystem {
     /// UML inherited base object
     // parent_message: true
@@ -1346,6 +1383,7 @@ pub struct ApplicationSystem {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "namedObject")]
     pub named_object: ::std::option::Option<NamedObject>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1355,6 +1393,7 @@ pub struct ApplicationSystem {
     // uuid: true
     // key: false
     #[prost(string, tag="2")]
+    #[serde(default, rename = "mRID")]
     pub m_rid: std::string::String,
 }
 mod application_system {
@@ -1404,8 +1443,7 @@ impl IsNamedObject for ApplicationSystem {
     }
 }
 /// Analogue setting (FC=SP) (ASG_SP)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Asg {
     /// The value of the analogue setting.
     // parent_message: false
@@ -1415,9 +1453,11 @@ pub struct Asg {
     // uuid: false
     // key: false
     #[prost(double, tag="1")]
+    #[serde(default, rename = "setMag")]
     pub set_mag: f64,
     /// Unit for 'setMag', 'minVal', 'maxVal', 'stepSize'.
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub units: ::std::option::Option<Unit>,
 }
 mod asg {
@@ -1453,8 +1493,7 @@ impl IsAsg for Asg {
     }
 }
 /// Binary counter reading (BCR)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Bcr {
     /// Binary counter status represented as an integer value; wraps to 0 at the maximum or minimum
     /// value of INT64.
@@ -1465,12 +1504,15 @@ pub struct Bcr {
     // uuid: false
     // key: false
     #[prost(int64, tag="1")]
+    #[serde(default, rename = "actVal")]
     pub act_val: i64,
     /// Quality of the values in 'actVal', 'frVal'.
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub q: ::std::option::Option<Quality>,
     /// Timestamp of the last change of value in 'actVal' or 'q'.
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub t: ::std::option::Option<Timestamp>,
 }
 mod bcr {
@@ -1513,11 +1555,11 @@ impl IsBcr for Bcr {
     }
 }
 /// Specialized 61850 SPS class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct StatusSps {
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub q: ::std::option::Option<Quality>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1527,9 +1569,11 @@ pub struct StatusSps {
     // uuid: false
     // key: false
     #[prost(bool, tag="2")]
+    #[serde(default, rename = "stVal")]
     pub st_val: bool,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub t: ::std::option::Option<Timestamp>,
 }
 mod status_sps {
@@ -1572,8 +1616,7 @@ impl IsStatusSps for StatusSps {
     }
 }
 /// LN: Generic process I/O   Name: GGIO
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct BooleanEventAndStatusGgio {
     /// UML inherited base object
     // parent_message: true
@@ -1583,6 +1626,7 @@ pub struct BooleanEventAndStatusGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNode")]
     pub logical_node: ::std::option::Option<LogicalNode>,
     /// If true, indication <i>n</i> is present.
     // parent_message: false
@@ -1592,9 +1636,11 @@ pub struct BooleanEventAndStatusGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "Ind")]
     pub ind: ::std::option::Option<StatusSps>,
     /// Phase code
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "Phase")]
     pub phase: ::std::option::Option<OptionalPhaseCodeKind>,
 }
 mod boolean_event_and_status_ggio {
@@ -1660,16 +1706,17 @@ impl IsIdentifiedObject for BooleanEventAndStatusGgio {
     }
 }
 /// IEC61850-7-2 Service parameter for conditions checking
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CheckConditions {
     /// InterlockCheck is used for the device to be controlled to check if other devices are in proper
     /// state for the control command.  One example is that 2 circuit breakers on a busbar need to be
     /// interlocked so one is open and one is closed, but not both on.
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "interlockCheck")]
     pub interlock_check: ::std::option::Option<bool>,
     /// To check if a device is synchrous to the system.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "synchroCheck")]
     pub synchro_check: ::std::option::Option<bool>,
 }
 mod check_conditions {
@@ -1706,12 +1753,12 @@ impl IsCheckConditions for CheckConditions {
     }
 }
 /// Vector definition (Vector)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Vector {
     /// (range=[-180...180]) Angle of the complex value (Unit.SIUnit='deg' and Unit.multiplier='');
     /// angle reference is defined in the context where this type is used.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub ang: ::std::option::Option<f64>,
     /// Magnitude of the complex value.
     // parent_message: false
@@ -1721,6 +1768,7 @@ pub struct Vector {
     // uuid: false
     // key: false
     #[prost(double, tag="2")]
+    #[serde(default)]
     pub mag: f64,
 }
 mod vector {
@@ -1756,8 +1804,7 @@ impl IsVector for Vector {
     }
 }
 /// Complex measured value (CMV)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Cmv {
     /// Complex value based on a deadband calculation from the instantaneous value 'instCVal.mag'. The
     /// deadband calculation is done both on 'instCVal.mag' (based on 'db') and on 'instCVal.ang' (based on
@@ -1769,13 +1816,16 @@ pub struct Cmv {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "cVal")]
     pub c_val: ::std::option::Option<Vector>,
     /// Quality of the values in 'instCVal', 'cVal', 'range', ‘rangeAng’.
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub q: ::std::option::Option<Quality>,
     /// Timestamp of the last refresh of the value in 'cVal' or of the last change of the value in any
     /// of 'range', 'rangeAng' or 'q'.
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub t: ::std::option::Option<Timestamp>,
 }
 mod cmv {
@@ -1819,8 +1869,7 @@ impl IsCmv for Cmv {
     }
 }
 /// Asset representation of a ConductingEquipment.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ConductingEquipment {
     /// UML inherited base object
     // parent_message: true
@@ -1830,6 +1879,7 @@ pub struct ConductingEquipment {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "namedObject")]
     pub named_object: ::std::option::Option<NamedObject>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1839,6 +1889,7 @@ pub struct ConductingEquipment {
     // uuid: true
     // key: true
     #[prost(string, tag="2")]
+    #[serde(default, rename = "mRID")]
     pub m_rid: std::string::String,
 }
 mod conducting_equipment {
@@ -1889,8 +1940,7 @@ impl IsNamedObject for ConductingEquipment {
 }
 /// An AC electrical connection point to a piece of conducting equipment. Terminals are connected at
 /// physical connection points called connectivity nodes.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Terminal {
     /// UML inherited base object
     // parent_message: true
@@ -1900,10 +1950,12 @@ pub struct Terminal {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "aCDCTerminal")]
     pub a_cdc_terminal: ::std::option::Option<AcdcTerminal>,
     /// Represents the normal network phasing condition. If the attribute is missing three phases (ABC
     /// or ABCN) shall be assumed.
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub phases: ::std::option::Option<OptionalPhaseCodeKind>,
 }
 mod terminal {
@@ -1962,8 +2014,7 @@ impl IsIdentifiedObject for Terminal {
     }
 }
 /// Reading associated with an equipment such as a recloser.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ConductingEquipmentTerminalReading {
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1973,6 +2024,7 @@ pub struct ConductingEquipmentTerminalReading {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub terminal: ::std::option::Option<Terminal>,
 }
 mod conducting_equipment_terminal_reading {
@@ -2002,8 +2054,7 @@ impl IsConductingEquipmentTerminalReading for ConductingEquipmentTerminalReading
     }
 }
 /// <<statistics>> Controllable analogue process value (APC)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ControlApc {
     /// Service parameter that determines the control activity.
     // parent_message: false
@@ -2013,6 +2064,7 @@ pub struct ControlApc {
     // uuid: false
     // key: false
     #[prost(double, tag="1")]
+    #[serde(default, rename = "ctlVal")]
     pub ctl_val: f64,
 }
 mod control_apc {
@@ -2041,8 +2093,7 @@ impl IsControlApc for ControlApc {
     }
 }
 /// Specialized DPC 61850 CDC class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ControlDpc {
     /// Service parameter that determines the control activity ('false' for off, 'true' for on).
     // parent_message: false
@@ -2052,6 +2103,7 @@ pub struct ControlDpc {
     // uuid: false
     // key: false
     #[prost(bool, tag="1")]
+    #[serde(default, rename = "ctlVal")]
     pub ctl_val: bool,
 }
 mod control_dpc {
@@ -2085,8 +2137,7 @@ impl IsControlDpc for ControlDpc {
 /// information related to time model are available as requirements in Clause 21.  ControlTimestamp is a
 /// timestamp for future time point so it does not contain the time quality as the one contained in the
 /// normal Timestamp data type.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ControlTimestamp {
     /// Second since epoch (1970-01-01T00:00:00Z)
     // parent_message: false
@@ -2096,6 +2147,7 @@ pub struct ControlTimestamp {
     // uuid: false
     // key: false
     #[prost(uint64, tag="2")]
+    #[serde(default)]
     pub seconds: u64,
     /// Partial (sub) second expressed in nanoseconds (10<sup>-9</sup> second).
     // parent_message: false
@@ -2105,6 +2157,7 @@ pub struct ControlTimestamp {
     // uuid: false
     // key: false
     #[prost(uint32, tag="3")]
+    #[serde(default)]
     pub nanoseconds: u32,
 }
 mod control_timestamp {
@@ -2138,10 +2191,10 @@ impl IsControlTimestamp for ControlTimestamp {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalScheduleParameterKind {
     #[prost(enumeration="ScheduleParameterKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_schedule_parameter_kind {
@@ -2170,8 +2223,7 @@ impl IsOptionalScheduleParameterKind for OptionalScheduleParameterKind {
     }
 }
 /// Grid connect mode kind
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EngScheduleParameter {
     /// Schedule parameter type
     // parent_message: false
@@ -2181,6 +2233,7 @@ pub struct EngScheduleParameter {
     // uuid: false
     // key: false
     #[prost(enumeration="ScheduleParameterKind", tag="1")]
+    #[serde(default, rename = "scheduleParameterType")]
     pub schedule_parameter_type: i32,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -2190,6 +2243,7 @@ pub struct EngScheduleParameter {
     // uuid: false
     // key: false
     #[prost(double, tag="2")]
+    #[serde(default)]
     pub value: f64,
 }
 mod eng_schedule_parameter {
@@ -2224,8 +2278,7 @@ impl IsEngScheduleParameter for EngScheduleParameter {
     }
 }
 /// Point definition (Point)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SchedulePoint {
     /// Schedule parameter
     // parent_message: false
@@ -2235,6 +2288,7 @@ pub struct SchedulePoint {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="1")]
+    #[serde(default, rename = "scheduleParameter")]
     pub schedule_parameter: ::std::vec::Vec<EngScheduleParameter>,
     /// Start time
     // parent_message: false
@@ -2244,6 +2298,7 @@ pub struct SchedulePoint {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "startTime")]
     pub start_time: ::std::option::Option<ControlTimestamp>,
 }
 mod schedule_point {
@@ -2279,8 +2334,7 @@ impl IsSchedulePoint for SchedulePoint {
     }
 }
 /// Curve shape setting (FC=SP) (CSG_SP)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ScheduleCsg {
     /// The array with the points specifying a time schedule
     // parent_message: false
@@ -2290,6 +2344,7 @@ pub struct ScheduleCsg {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="1")]
+    #[serde(default, rename = "schPts")]
     pub sch_pts: ::std::vec::Vec<SchedulePoint>,
 }
 mod schedule_csg {
@@ -2318,8 +2373,7 @@ impl IsScheduleCsg for ScheduleCsg {
     }
 }
 /// OpenFMB specialization for control schedule using:  LN: Schedule   Name: FSCH
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ControlScheduleFsch {
     /// Analog CSG
     // parent_message: false
@@ -2329,6 +2383,7 @@ pub struct ControlScheduleFsch {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "ValACSG")]
     pub val_acsg: ::std::option::Option<ScheduleCsg>,
 }
 mod control_schedule_fsch {
@@ -2358,8 +2413,7 @@ impl IsControlScheduleFsch for ControlScheduleFsch {
     }
 }
 /// OpenFMB specialization for logical node control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LogicalNodeForControl {
     /// UML inherited base object
     // parent_message: true
@@ -2369,6 +2423,7 @@ pub struct LogicalNodeForControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNode")]
     pub logical_node: ::std::option::Option<LogicalNode>,
 }
 mod logical_node_for_control {
@@ -2421,8 +2476,7 @@ impl IsIdentifiedObject for LogicalNodeForControl {
 }
 /// LN: Schedule controller   Name: FSCC  F:    Function (generic) SC:  Schedule Controller C:   
 /// Control (execution)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ControlFscc {
     /// UML inherited base object
     // parent_message: true
@@ -2432,12 +2486,15 @@ pub struct ControlFscc {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForControl")]
     pub logical_node_for_control: ::std::option::Option<LogicalNodeForControl>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "controlScheduleFSCH")]
     pub control_schedule_fsch: ::std::option::Option<ControlScheduleFsch>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "islandControlScheduleFSCH")]
     pub island_control_schedule_fsch: ::std::option::Option<ControlScheduleFsch>,
 }
 mod control_fscc {
@@ -2511,8 +2568,7 @@ impl IsIdentifiedObject for ControlFscc {
     }
 }
 /// &lt;&lt;statistics&gt;&gt; Controllable integer status (INC)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ControlInc {
     /// Service parameter that determines the control activity.
     // parent_message: false
@@ -2522,6 +2578,7 @@ pub struct ControlInc {
     // uuid: false
     // key: false
     #[prost(int32, tag="1")]
+    #[serde(default, rename = "ctlVal")]
     pub ctl_val: i32,
 }
 mod control_inc {
@@ -2550,8 +2607,7 @@ impl IsControlInc for ControlInc {
     }
 }
 /// Integer status setting (FC=SP) (ING_SP)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ControlIng {
     /// The value of the status setting.
     // parent_message: false
@@ -2561,9 +2617,11 @@ pub struct ControlIng {
     // uuid: false
     // key: false
     #[prost(int32, tag="1")]
+    #[serde(default, rename = "setVal")]
     pub set_val: i32,
     /// Unit for 'setVal', 'minVal', 'maxVal', 'stepSize'.
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub units: ::std::option::Option<Unit>,
 }
 mod control_ing {
@@ -2599,8 +2657,7 @@ impl IsControlIng for ControlIng {
     }
 }
 /// &lt;&lt;statistics&gt;&gt; Integer controlled step position information (ISC)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ControlIsc {
     /// Service parameter that determines the control activity.
     // parent_message: false
@@ -2610,6 +2667,7 @@ pub struct ControlIsc {
     // uuid: false
     // key: false
     #[prost(int32, tag="1")]
+    #[serde(default, rename = "ctlVal")]
     pub ctl_val: i32,
 }
 mod control_isc {
@@ -2638,8 +2696,7 @@ impl IsControlIsc for ControlIsc {
     }
 }
 /// Generic control message info.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct MessageInfo {
     /// UML inherited base object
     // parent_message: true
@@ -2649,6 +2706,7 @@ pub struct MessageInfo {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<IdentifiedObject>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -2658,6 +2716,7 @@ pub struct MessageInfo {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "messageTimeStamp")]
     pub message_time_stamp: ::std::option::Option<Timestamp>,
 }
 mod message_info {
@@ -2708,8 +2767,7 @@ impl IsIdentifiedObject for MessageInfo {
     }
 }
 /// Generic control message info.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ControlMessageInfo {
     /// UML inherited base object
     // parent_message: true
@@ -2719,6 +2777,7 @@ pub struct ControlMessageInfo {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "messageInfo")]
     pub message_info: ::std::option::Option<MessageInfo>,
 }
 mod control_message_info {
@@ -2770,8 +2829,7 @@ impl IsIdentifiedObject for ControlMessageInfo {
     }
 }
 /// Controllable single point (SPC)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ControlSpc {
     /// Service parameter that determines the control activity ('false' for off or deactivation, 'true'
     /// for on or activation).
@@ -2782,6 +2840,7 @@ pub struct ControlSpc {
     // uuid: false
     // key: false
     #[prost(bool, tag="1")]
+    #[serde(default, rename = "ctlVal")]
     pub ctl_val: bool,
 }
 mod control_spc {
@@ -2813,8 +2872,7 @@ impl IsControlSpc for ControlSpc {
 /// The attribute modBlk is used to tag out a device. if it is TRUE, any setpoints and control schedule
 /// in a message payload should be ignored.   It should also be presented in a status profile.  Any
 /// modBlk value change (i.e. TRUE to FALSE and vice versa) should trigger an event.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ControlValue {
     /// UML inherited base object
     // parent_message: true
@@ -2824,14 +2882,17 @@ pub struct ControlValue {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<IdentifiedObject>,
     /// The attribute modBlk is used to tag out a device. If it is TRUE, any setpoints and control in a
     /// message payload should be ignored.   It should also be presented in a status profile.  Any modBlk
     /// value change (i.e. TRUE to FALSE and vice versa) should trigger an event.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "modBlk")]
     pub mod_blk: ::std::option::Option<bool>,
     /// If true, reset the device before executing any other controls.
     #[prost(message, optional, tag="4")]
+    #[serde(default)]
     pub reset: ::std::option::Option<bool>,
 }
 mod control_value {
@@ -2889,14 +2950,15 @@ impl IsIdentifiedObject for ControlValue {
     }
 }
 /// Interval between two date and time points.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct DateTimeInterval {
     /// End date and time of this interval.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub end: ::std::option::Option<i64>,
     /// Start date and time of this interval.
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub start: ::std::option::Option<i64>,
 }
 mod date_time_interval {
@@ -2933,17 +2995,19 @@ impl IsDateTimeInterval for DateTimeInterval {
     }
 }
 /// Phase to phase related measured values of a three-phase system (DEL)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Del {
     /// Value of phase A to phase B measurement.
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "phsAB")]
     pub phs_ab: ::std::option::Option<Cmv>,
     /// Value of phase B to phase C measurement.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phsBC")]
     pub phs_bc: ::std::option::Option<Cmv>,
     /// Value of phase C to phase A measurement.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "phsCA")]
     pub phs_ca: ::std::option::Option<Cmv>,
 }
 mod del {
@@ -2987,20 +3051,23 @@ impl IsDel for Del {
     }
 }
 /// [OpenFMB CDC extension] Per Phase DPC.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct PhaseDpc {
     /// 3 Phase control.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub phs3: ::std::option::Option<ControlDpc>,
     /// Phase A control.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phsA")]
     pub phs_a: ::std::option::Option<ControlDpc>,
     /// Phase B control.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "phsB")]
     pub phs_b: ::std::option::Option<ControlDpc>,
     /// Phase C control.
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "phsC")]
     pub phs_c: ::std::option::Option<ControlDpc>,
 }
 mod phase_dpc {
@@ -3051,8 +3118,7 @@ impl IsPhaseDpc for PhaseDpc {
     }
 }
 /// Reclose enabled
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct DiscreteControlXcbr {
     /// UML inherited base object
     // parent_message: true
@@ -3062,19 +3128,24 @@ pub struct DiscreteControlXcbr {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForControl")]
     pub logical_node_for_control: ::std::option::Option<LogicalNodeForControl>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "Pos")]
     pub pos: ::std::option::Option<PhaseDpc>,
     /// Protection mode such as a group setting or pre-defined curve profile. It is usually pre-defined
     /// by a circuit segment service.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "ProtectionMode")]
     pub protection_mode: ::std::option::Option<ControlInc>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "RecloseEnabled")]
     pub reclose_enabled: ::std::option::Option<ControlSpc>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "ResetProtectionPickup")]
     pub reset_protection_pickup: ::std::option::Option<ControlSpc>,
 }
 mod discrete_control_xcbr {
@@ -3162,8 +3233,7 @@ impl IsIdentifiedObject for DiscreteControlXcbr {
     }
 }
 /// Generic user of energy - a  point of consumption on the power system model.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EnergyConsumer {
     /// UML inherited base object
     // parent_message: true
@@ -3173,9 +3243,11 @@ pub struct EnergyConsumer {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipment")]
     pub conducting_equipment: ::std::option::Option<ConductingEquipment>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "operatingLimit")]
     pub operating_limit: ::std::option::Option<::std::string::String>,
 }
 mod energy_consumer {
@@ -3233,10 +3305,10 @@ impl IsNamedObject for EnergyConsumer {
         self.parent_mut().parent_mut()
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalCalcMethodKind {
     #[prost(enumeration="CalcMethodKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_calc_method_kind {
@@ -3265,8 +3337,7 @@ impl IsOptionalCalcMethodKind for OptionalCalcMethodKind {
     }
 }
 /// Calc method kind
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EngCalcMethodKind {
     /// The value of the status setting.
     // parent_message: false
@@ -3276,6 +3347,7 @@ pub struct EngCalcMethodKind {
     // uuid: false
     // key: false
     #[prost(enumeration="CalcMethodKind", tag="1")]
+    #[serde(default, rename = "setVal")]
     pub set_val: i32,
 }
 mod eng_calc_method_kind {
@@ -3303,10 +3375,10 @@ impl IsEngCalcMethodKind for EngCalcMethodKind {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalGridConnectModeKind {
     #[prost(enumeration="GridConnectModeKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_grid_connect_mode_kind {
@@ -3335,8 +3407,7 @@ impl IsOptionalGridConnectModeKind for OptionalGridConnectModeKind {
     }
 }
 /// Grid connect mode kind
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EngGridConnectModeKind {
     /// The value of the status setting.
     // parent_message: false
@@ -3346,9 +3417,11 @@ pub struct EngGridConnectModeKind {
     // uuid: false
     // key: false
     #[prost(enumeration="GridConnectModeKind", tag="1")]
+    #[serde(default, rename = "setVal")]
     pub set_val: i32,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "setValExtension")]
     pub set_val_extension: ::std::option::Option<::std::string::String>,
 }
 mod eng_grid_connect_mode_kind {
@@ -3383,10 +3456,10 @@ impl IsEngGridConnectModeKind for EngGridConnectModeKind {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalPfSignKind {
     #[prost(enumeration="PfSignKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_pf_sign_kind {
@@ -3415,8 +3488,7 @@ impl IsOptionalPfSignKind for OptionalPfSignKind {
     }
 }
 /// Enumerated status setting (FC=SP) (ENG_SP)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EngPfSignKind {
     /// The value of the status setting.
     // parent_message: false
@@ -3426,6 +3498,7 @@ pub struct EngPfSignKind {
     // uuid: false
     // key: false
     #[prost(enumeration="PfSignKind", tag="1")]
+    #[serde(default, rename = "setVal")]
     pub set_val: i32,
 }
 mod eng_pf_sign_kind {
@@ -3453,10 +3526,10 @@ impl IsEngPfSignKind for EngPfSignKind {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalBehaviourModeKind {
     #[prost(enumeration="BehaviourModeKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_behaviour_mode_kind {
@@ -3485,11 +3558,11 @@ impl IsOptionalBehaviourModeKind for OptionalBehaviourModeKind {
     }
 }
 /// Behavior mode kind. ENS stands for Enumerated status
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EnsBehaviourModeKind {
     /// Quality of the value in 'stVal'.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub q: ::std::option::Option<Quality>,
     /// Value of the data.
     // parent_message: false
@@ -3499,9 +3572,11 @@ pub struct EnsBehaviourModeKind {
     // uuid: false
     // key: false
     #[prost(enumeration="BehaviourModeKind", tag="2")]
+    #[serde(default, rename = "stVal")]
     pub st_val: i32,
     /// Timestamp of the last change or update event of 'stVal' or the last change of value in 'q'.
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub t: ::std::option::Option<Timestamp>,
 }
 mod ens_behaviour_mode_kind {
@@ -3543,10 +3618,10 @@ impl IsEnsBehaviourModeKind for EnsBehaviourModeKind {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalDerGeneratorStateKind {
     #[prost(enumeration="DerGeneratorStateKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_der_generator_state_kind {
@@ -3575,11 +3650,11 @@ impl IsOptionalDerGeneratorStateKind for OptionalDerGeneratorStateKind {
     }
 }
 /// DER generation state kind. ENS stands for Enumerated status
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EnsDerGeneratorStateKind {
     /// Quality of the value in 'stVal'.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub q: ::std::option::Option<Quality>,
     /// Value of the data.
     // parent_message: false
@@ -3589,9 +3664,11 @@ pub struct EnsDerGeneratorStateKind {
     // uuid: false
     // key: false
     #[prost(enumeration="DerGeneratorStateKind", tag="2")]
+    #[serde(default, rename = "stVal")]
     pub st_val: i32,
     /// Timestamp of the last change or update event of 'stVal' or the last change of value in 'q'.
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub t: ::std::option::Option<Timestamp>,
 }
 mod ens_der_generator_state_kind {
@@ -3633,10 +3710,10 @@ impl IsEnsDerGeneratorStateKind for EnsDerGeneratorStateKind {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalDynamicTestKind {
     #[prost(enumeration="DynamicTestKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_dynamic_test_kind {
@@ -3665,11 +3742,11 @@ impl IsOptionalDynamicTestKind for OptionalDynamicTestKind {
     }
 }
 /// Dynamic test kind. ENS stands for Enumerated status
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EnsDynamicTestKind {
     /// Quality of the value in 'stVal'.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub q: ::std::option::Option<Quality>,
     /// Value of the data.
     // parent_message: false
@@ -3679,9 +3756,11 @@ pub struct EnsDynamicTestKind {
     // uuid: false
     // key: false
     #[prost(enumeration="DynamicTestKind", tag="2")]
+    #[serde(default, rename = "stVal")]
     pub st_val: i32,
     /// Timestamp of the last change or update event of 'stVal' or the last change of value in 'q'.
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub t: ::std::option::Option<Timestamp>,
 }
 mod ens_dynamic_test_kind {
@@ -3724,8 +3803,7 @@ impl IsEnsDynamicTestKind for EnsDynamicTestKind {
     }
 }
 /// Grid connect event &amp; status mode kind
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EnsGridConnectModeKind {
     /// Actual Grid Connection Mode
     // parent_message: false
@@ -3735,6 +3813,7 @@ pub struct EnsGridConnectModeKind {
     // uuid: false
     // key: false
     #[prost(enumeration="GridConnectModeKind", tag="1")]
+    #[serde(default, rename = "stVal")]
     pub st_val: i32,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -3744,6 +3823,7 @@ pub struct EnsGridConnectModeKind {
     // uuid: false
     // key: false
     #[prost(string, tag="2")]
+    #[serde(default, rename = "stValExtension")]
     pub st_val_extension: std::string::String,
 }
 mod ens_grid_connect_mode_kind {
@@ -3777,10 +3857,10 @@ impl IsEnsGridConnectModeKind for EnsGridConnectModeKind {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalHealthKind {
     #[prost(enumeration="HealthKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_health_kind {
@@ -3809,12 +3889,12 @@ impl IsOptionalHealthKind for OptionalHealthKind {
     }
 }
 /// &lt;&gt; Enumerated status (ENS)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EnsHealthKind {
     /// Textual description of the data. In case it is used within the CDC LPL, the description refers
     /// to the logical node.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub d: ::std::option::Option<::std::string::String>,
     /// Value of the data.
     // parent_message: false
@@ -3824,6 +3904,7 @@ pub struct EnsHealthKind {
     // uuid: false
     // key: false
     #[prost(enumeration="HealthKind", tag="2")]
+    #[serde(default, rename = "stVal")]
     pub st_val: i32,
 }
 mod ens_health_kind {
@@ -3858,10 +3939,10 @@ impl IsEnsHealthKind for EnsHealthKind {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalSwitchingCapabilityKind {
     #[prost(enumeration="SwitchingCapabilityKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_switching_capability_kind {
@@ -3890,11 +3971,11 @@ impl IsOptionalSwitchingCapabilityKind for OptionalSwitchingCapabilityKind {
     }
 }
 /// <<abstract>> Enumerated status (ENS)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EnsSwitchingCapabilityKind {
     /// If true, 'q.operatorBlocked'=true, and the process value is no longer updated.
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "blkEna")]
     pub blk_ena: ::std::option::Option<bool>,
     /// Value of the data.
     // parent_message: false
@@ -3904,6 +3985,7 @@ pub struct EnsSwitchingCapabilityKind {
     // uuid: false
     // key: false
     #[prost(enumeration="SwitchingCapabilityKind", tag="2")]
+    #[serde(default, rename = "stVal")]
     pub st_val: i32,
 }
 mod ens_switching_capability_kind {
@@ -3939,8 +4021,7 @@ impl IsEnsSwitchingCapabilityKind for EnsSwitchingCapabilityKind {
     }
 }
 /// MISSING DOCUMENTATION!!!
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Ess {
     /// UML inherited base object
     // parent_message: true
@@ -3950,6 +4031,7 @@ pub struct Ess {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipment")]
     pub conducting_equipment: ::std::option::Option<ConductingEquipment>,
 }
 mod ess {
@@ -4001,8 +4083,7 @@ impl IsNamedObject for Ess {
     }
 }
 /// Generic event message information
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EventMessageInfo {
     /// UML inherited base object
     // parent_message: true
@@ -4012,6 +4093,7 @@ pub struct EventMessageInfo {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "messageInfo")]
     pub message_info: ::std::option::Option<MessageInfo>,
 }
 mod event_message_info {
@@ -4063,8 +4145,7 @@ impl IsIdentifiedObject for EventMessageInfo {
     }
 }
 /// Event value
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EventValue {
     /// UML inherited base object
     // parent_message: true
@@ -4074,9 +4155,11 @@ pub struct EventValue {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<IdentifiedObject>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "modBlk")]
     pub mod_blk: ::std::option::Option<bool>,
 }
 mod event_value {
@@ -4127,8 +4210,7 @@ impl IsIdentifiedObject for EventValue {
     }
 }
 /// The source where a forecast value is issued.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ForecastValueSource {
     /// UML inherited base object
     // parent_message: true
@@ -4138,6 +4220,7 @@ pub struct ForecastValueSource {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<IdentifiedObject>,
 }
 mod forecast_value_source {
@@ -4188,8 +4271,7 @@ impl IsIdentifiedObject for ForecastValueSource {
 /// IED with an IEC61850 SERVER, we typically create an instance of the meta-model IED per connection.
 /// When the meta-model gets instantiated from an SCL file, there is the full description of IED and its
 /// functions.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ForecastIed {
     /// UML inherited base object
     // parent_message: true
@@ -4199,6 +4281,7 @@ pub struct ForecastIed {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "forecastValueSource")]
     pub forecast_value_source: ::std::option::Option<ForecastValueSource>,
     /// For control, this is an application ID, unique within communication system, and if the message
     /// is transformed between gateway the original source application ID should be kept.
@@ -4209,6 +4292,7 @@ pub struct ForecastIed {
     // uuid: false
     // key: false
     #[prost(string, tag="2")]
+    #[serde(default, rename = "sourceApplicationID")]
     pub source_application_id: std::string::String,
     /// Message publication date time
     // parent_message: false
@@ -4218,6 +4302,7 @@ pub struct ForecastIed {
     // uuid: false
     // key: false
     #[prost(int64, tag="3")]
+    #[serde(default, rename = "sourceDateTime")]
     pub source_date_time: i64,
 }
 mod forecast_ied {
@@ -4281,8 +4366,7 @@ impl IsIdentifiedObject for ForecastIed {
     }
 }
 /// Forecast value
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ForecastValue {
     /// UML inherited base object
     // parent_message: true
@@ -4292,6 +4376,7 @@ pub struct ForecastValue {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<IdentifiedObject>,
 }
 mod forecast_value {
@@ -4335,11 +4420,11 @@ impl IsIdentifiedObject for ForecastValue {
     }
 }
 /// <<statistics>> Integer status (INS)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct StatusIns {
     /// Quality of the value in 'stVal'.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub q: ::std::option::Option<Quality>,
     /// Value of the data.
     // parent_message: false
@@ -4349,9 +4434,11 @@ pub struct StatusIns {
     // uuid: false
     // key: false
     #[prost(int32, tag="2")]
+    #[serde(default, rename = "stVal")]
     pub st_val: i32,
     /// Timestamp of the last change or update event of 'stVal' or the last change of value in 'q'.
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub t: ::std::option::Option<Timestamp>,
 }
 mod status_ins {
@@ -4394,8 +4481,7 @@ impl IsStatusIns for StatusIns {
     }
 }
 /// Status expressed in integer based on IEC61850 GGIO.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct IntegerEventAndStatusGgio {
     /// UML inherited base object
     // parent_message: true
@@ -4405,6 +4491,7 @@ pub struct IntegerEventAndStatusGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNode")]
     pub logical_node: ::std::option::Option<LogicalNode>,
     /// Generic integer status input <i>n</i>.
     // parent_message: false
@@ -4414,9 +4501,11 @@ pub struct IntegerEventAndStatusGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "IntIn")]
     pub int_in: ::std::option::Option<StatusIns>,
     /// Phase code
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "Phase")]
     pub phase: ::std::option::Option<OptionalPhaseCodeKind>,
 }
 mod integer_event_and_status_ggio {
@@ -4482,8 +4571,7 @@ impl IsIdentifiedObject for IntegerEventAndStatusGgio {
     }
 }
 /// Logical node for event and status
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LogicalNodeForEventAndStatus {
     /// UML inherited base object
     // parent_message: true
@@ -4493,18 +4581,23 @@ pub struct LogicalNodeForEventAndStatus {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNode")]
     pub logical_node: ::std::option::Option<LogicalNode>,
     /// Behavior of the function
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "Beh")]
     pub beh: ::std::option::Option<EnsBehaviourModeKind>,
     /// Asset health
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "EEHealth")]
     pub ee_health: ::std::option::Option<EnsHealthKind>,
     /// Hot line tag.
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "HotLineTag")]
     pub hot_line_tag: ::std::option::Option<StatusSps>,
     /// Remote control block.
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "RemoteBlk")]
     pub remote_blk: ::std::option::Option<StatusSps>,
 }
 mod logical_node_for_event_and_status {
@@ -4586,8 +4679,7 @@ impl IsIdentifiedObject for LogicalNodeForEventAndStatus {
 /// The current state for a measurement. A state value is an instance of a measurement from a
 /// specific source. Measurements can be associated with many state values, each representing a
 /// different source for the measurement.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct MeasurementValue {
     /// UML inherited base object
     // parent_message: true
@@ -4597,6 +4689,7 @@ pub struct MeasurementValue {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<IdentifiedObject>,
 }
 mod measurement_value {
@@ -4641,8 +4734,7 @@ impl IsIdentifiedObject for MeasurementValue {
 }
 /// Physical asset that performs the metering role of the usage point. Used for measuring
 /// consumption and detection of events.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Meter {
     /// UML inherited base object
     // parent_message: true
@@ -4652,6 +4744,7 @@ pub struct Meter {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipment")]
     pub conducting_equipment: ::std::option::Option<ConductingEquipment>,
 }
 mod meter {
@@ -4703,8 +4796,7 @@ impl IsNamedObject for Meter {
     }
 }
 /// Generic event message information
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptimizationMessageInfo {
     /// UML inherited base object
     // parent_message: true
@@ -4714,6 +4806,7 @@ pub struct OptimizationMessageInfo {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "messageInfo")]
     pub message_info: ::std::option::Option<MessageInfo>,
 }
 mod optimization_message_info {
@@ -4765,20 +4858,23 @@ impl IsIdentifiedObject for OptimizationMessageInfo {
     }
 }
 /// [OpenFMB CDC extension] Per Phase ISC.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct PhaseApc {
     /// 3 Phase control.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub phs3: ::std::option::Option<ControlApc>,
     /// Phase A control.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phsA")]
     pub phs_a: ::std::option::Option<ControlApc>,
     /// Phase B control.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "phsB")]
     pub phs_b: ::std::option::Option<ControlApc>,
     /// Phase C control.
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "phsC")]
     pub phs_c: ::std::option::Option<ControlApc>,
 }
 mod phase_apc {
@@ -4828,10 +4924,10 @@ impl IsPhaseApc for PhaseApc {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalDbPosKind {
     #[prost(enumeration="DbPosKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_db_pos_kind {
@@ -4860,11 +4956,11 @@ impl IsOptionalDbPosKind for OptionalDbPosKind {
     }
 }
 /// Specialized 61850 DPS class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct StatusDps {
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub q: ::std::option::Option<Quality>,
     /// Status value of the controllable data object.
     // parent_message: false
@@ -4874,9 +4970,11 @@ pub struct StatusDps {
     // uuid: false
     // key: false
     #[prost(enumeration="DbPosKind", tag="2")]
+    #[serde(default, rename = "stVal")]
     pub st_val: i32,
     /// Timestamp of the last change of the value in any of 'stVal' or 'q'.
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub t: ::std::option::Option<Timestamp>,
 }
 mod status_dps {
@@ -4919,20 +5017,23 @@ impl IsStatusDps for StatusDps {
     }
 }
 /// [OpenFMB CDC extension] Per Phase DPS.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct PhaseDps {
     /// 3 Phase status.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub phs3: ::std::option::Option<StatusDps>,
     /// Phase A status.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phsA")]
     pub phs_a: ::std::option::Option<StatusDps>,
     /// Phase B status.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "phsB")]
     pub phs_b: ::std::option::Option<StatusDps>,
     /// Phase C status.
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "phsC")]
     pub phs_c: ::std::option::Option<StatusDps>,
 }
 mod phase_dps {
@@ -4983,20 +5084,23 @@ impl IsPhaseDps for PhaseDps {
     }
 }
 /// [OpenFMB CDC extension] Per Phase INS.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct PhaseIns {
     /// 3 Phase control.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub phs3: ::std::option::Option<StatusIns>,
     /// Phase A control.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phsA")]
     pub phs_a: ::std::option::Option<StatusIns>,
     /// Phase B control.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "phsB")]
     pub phs_b: ::std::option::Option<StatusIns>,
     /// Phase C control.
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "phsC")]
     pub phs_c: ::std::option::Option<StatusIns>,
 }
 mod phase_ins {
@@ -5047,20 +5151,23 @@ impl IsPhaseIns for PhaseIns {
     }
 }
 /// [OpenFMB CDC extension] Per Phase ISC.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct PhaseIsc {
     /// 3 Phase control.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub phs3: ::std::option::Option<ControlIsc>,
     /// Phase A control.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phsA")]
     pub phs_a: ::std::option::Option<ControlIsc>,
     /// Phase B control.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "phsB")]
     pub phs_b: ::std::option::Option<ControlIsc>,
     /// Phase C control.
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "phsC")]
     pub phs_c: ::std::option::Option<ControlIsc>,
 }
 mod phase_isc {
@@ -5111,8 +5218,7 @@ impl IsPhaseIsc for PhaseIsc {
     }
 }
 /// Specialized 61850 MMTN LN class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ReadingMmtn {
     /// UML inherited base object
     // parent_message: true
@@ -5122,33 +5228,43 @@ pub struct ReadingMmtn {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNode")]
     pub logical_node: ::std::option::Option<LogicalNode>,
     /// Apparent energy demand (direction: from busbar).
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "DmdVAh")]
     pub dmd_v_ah: ::std::option::Option<Bcr>,
     /// Reactive energy demand (direction: from busbar).
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "DmdVArh")]
     pub dmd_v_arh: ::std::option::Option<Bcr>,
     /// Real energy demand (direction: from busbar).
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "DmdWh")]
     pub dmd_wh: ::std::option::Option<Bcr>,
     /// Apparent energy supply (default direction: towards busbar).
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "SupVAh")]
     pub sup_v_ah: ::std::option::Option<Bcr>,
     /// Reactive energy supply (default direction: towards busbar).
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "SupVArh")]
     pub sup_v_arh: ::std::option::Option<Bcr>,
     /// Real energy supply (default direction: towards busbar).
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "SupWh")]
     pub sup_wh: ::std::option::Option<Bcr>,
     /// Net apparent energy since last reset.
     #[prost(message, optional, tag="8")]
+    #[serde(default, rename = "TotVAh")]
     pub tot_v_ah: ::std::option::Option<Bcr>,
     /// Net reactive energy since last reset.
     #[prost(message, optional, tag="9")]
+    #[serde(default, rename = "TotVArh")]
     pub tot_v_arh: ::std::option::Option<Bcr>,
     /// Net real energy since last reset.
     #[prost(message, optional, tag="10")]
+    #[serde(default, rename = "TotWh")]
     pub tot_wh: ::std::option::Option<Bcr>,
 }
 mod reading_mmtn {
@@ -5263,26 +5379,31 @@ impl IsIdentifiedObject for ReadingMmtn {
     }
 }
 /// Specialized 61850 MMTN LN class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct PhaseMmtn {
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "phsA")]
     pub phs_a: ::std::option::Option<ReadingMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phsAB")]
     pub phs_ab: ::std::option::Option<ReadingMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "phsB")]
     pub phs_b: ::std::option::Option<ReadingMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "phsBC")]
     pub phs_bc: ::std::option::Option<ReadingMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "phsC")]
     pub phs_c: ::std::option::Option<ReadingMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "phsCA")]
     pub phs_ca: ::std::option::Option<ReadingMmtn>,
 }
 mod phase_mmtn {
@@ -5346,10 +5467,10 @@ impl IsPhaseMmtn for PhaseMmtn {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalRecloseActionKind {
     #[prost(enumeration="RecloseActionKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_reclose_action_kind {
@@ -5378,20 +5499,23 @@ impl IsOptionalRecloseActionKind for OptionalRecloseActionKind {
     }
 }
 /// [OpenFMB CDC extension] Per Phase reclose action kind.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct PhaseRecloseAction {
     /// 3 Phase control.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub phs3: ::std::option::Option<OptionalRecloseActionKind>,
     /// Phase A control.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phsA")]
     pub phs_a: ::std::option::Option<OptionalRecloseActionKind>,
     /// Phase B control.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "phsB")]
     pub phs_b: ::std::option::Option<OptionalRecloseActionKind>,
     /// Phase C control.
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "phsC")]
     pub phs_c: ::std::option::Option<OptionalRecloseActionKind>,
 }
 mod phase_reclose_action {
@@ -5442,20 +5566,23 @@ impl IsPhaseRecloseAction for PhaseRecloseAction {
     }
 }
 /// [OpenFMB CDC extension] Per Phase DPS.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct PhaseSps {
     /// 3 Phase status.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub phs3: ::std::option::Option<StatusSps>,
     /// Phase A status.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phsA")]
     pub phs_a: ::std::option::Option<StatusSps>,
     /// Phase B status.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "phsB")]
     pub phs_b: ::std::option::Option<StatusSps>,
     /// Phase C status.
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "phsC")]
     pub phs_c: ::std::option::Option<StatusSps>,
 }
 mod phase_sps {
@@ -5507,22 +5634,25 @@ impl IsPhaseSps for PhaseSps {
 }
 /// [OpenFMB CDC extension] Phase magnitude (PMG). Phase to ground/neutral related per-phase
 /// measured values.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Pmg {
     /// Net current, as the algebraic sum of the instantaneous values of currents flowing through all
     /// live conductors and the neutral of a circuit at one point of the electrical installation ('phsA
     /// instCVal'+'phsB.instCVal'+'phsC.instCVal'+'neut.instCVal').
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub net: ::std::option::Option<Mv>,
     /// Value of phase A.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phsA")]
     pub phs_a: ::std::option::Option<Mv>,
     /// Value of phase B.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "phsB")]
     pub phs_b: ::std::option::Option<Mv>,
     /// Value of phase C.
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "phsC")]
     pub phs_c: ::std::option::Option<Mv>,
 }
 mod pmg {
@@ -5573,20 +5703,23 @@ impl IsPmg for Pmg {
     }
 }
 /// Grid connect mode kind
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RampRate {
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "negativeReactivePowerKVArPerMin")]
     pub negative_reactive_power_kv_ar_per_min: ::std::option::Option<f32>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "negativeRealPowerKWPerMin")]
     pub negative_real_power_kw_per_min: ::std::option::Option<f32>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "positiveReactivePowerKVArPerMin")]
     pub positive_reactive_power_kv_ar_per_min: ::std::option::Option<f32>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "positiveRealPowerKWPerMin")]
     pub positive_real_power_kw_per_min: ::std::option::Option<f32>,
 }
 mod ramp_rate {
@@ -5637,8 +5770,7 @@ impl IsRampRate for RampRate {
     }
 }
 /// Generic reading message information
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ReadingMessageInfo {
     /// UML inherited base object
     // parent_message: true
@@ -5648,6 +5780,7 @@ pub struct ReadingMessageInfo {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "messageInfo")]
     pub message_info: ::std::option::Option<MessageInfo>,
 }
 mod reading_message_info {
@@ -5699,8 +5832,7 @@ impl IsIdentifiedObject for ReadingMessageInfo {
     }
 }
 /// Specialized 61850 MMTR class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ReadingMmtr {
     /// UML inherited base object
     // parent_message: true
@@ -5710,33 +5842,43 @@ pub struct ReadingMmtr {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNode")]
     pub logical_node: ::std::option::Option<LogicalNode>,
     /// Apparent energy demand (direction: from busbar).
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "DmdVAh")]
     pub dmd_v_ah: ::std::option::Option<Bcr>,
     /// Reactive energy demand (direction: from busbar).
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "DmdVArh")]
     pub dmd_v_arh: ::std::option::Option<Bcr>,
     /// Real energy demand (direction: from busbar).
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "DmdWh")]
     pub dmd_wh: ::std::option::Option<Bcr>,
     /// Apparent energy supply (default direction: towards busbar).
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "SupVAh")]
     pub sup_v_ah: ::std::option::Option<Bcr>,
     /// Reactive energy supply (default direction: towards busbar).
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "SupVArh")]
     pub sup_v_arh: ::std::option::Option<Bcr>,
     /// Real energy supply (default direction: towards busbar).
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "SupWh")]
     pub sup_wh: ::std::option::Option<Bcr>,
     /// Net apparent energy since last reset.
     #[prost(message, optional, tag="8")]
+    #[serde(default, rename = "TotVAh")]
     pub tot_v_ah: ::std::option::Option<Bcr>,
     /// Net reactive energy since last reset.
     #[prost(message, optional, tag="9")]
+    #[serde(default, rename = "TotVArh")]
     pub tot_v_arh: ::std::option::Option<Bcr>,
     /// Net real energy since last reset.
     #[prost(message, optional, tag="10")]
+    #[serde(default, rename = "TotWh")]
     pub tot_wh: ::std::option::Option<Bcr>,
 }
 mod reading_mmtr {
@@ -5851,28 +5993,32 @@ impl IsIdentifiedObject for ReadingMmtr {
     }
 }
 /// Phase to ground/neutral related measured values of a three-phase system (WYE)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Wye {
     /// Net current, as the algebraic sum of the instantaneous values of currents flowing through all
     /// live conductors and the neutral of a circuit at one point of the electrical installation ('phsA
     /// instCVal'+'phsB.instCVal'+'phsC.instCVal'+'neut.instCVal').
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub net: ::std::option::Option<Cmv>,
     /// Value of the measured phase neutral. If a direct measurement of this value is not available, it
     /// is acceptable to substitute an estimate computed by creating the algebraic sum of the instantaneous
     /// values of currents flowing through all live conductors ('phsA.instCVal'+'phsB.instCVal'+'phsC
     /// instCVal'); in that case, 'neut'='res'.
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub neut: ::std::option::Option<Cmv>,
     /// Value of phase A.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "phsA")]
     pub phs_a: ::std::option::Option<Cmv>,
     /// Value of phase B.
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "phsB")]
     pub phs_b: ::std::option::Option<Cmv>,
     /// Value of phase C.
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "phsC")]
     pub phs_c: ::std::option::Option<Cmv>,
 }
 mod wye {
@@ -5930,8 +6076,7 @@ impl IsWye for Wye {
     }
 }
 /// Specialized 61850 MMXU LN class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ReadingMmxu {
     /// UML inherited base object
     // parent_message: true
@@ -5941,9 +6086,11 @@ pub struct ReadingMmxu {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNode")]
     pub logical_node: ::std::option::Option<LogicalNode>,
     /// Phase to ground/phase to neutral three phase currents.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "A")]
     pub a: ::std::option::Option<Wye>,
     /// Kind of statistical calculation, specifying how the data attributes that represent analogue
     /// values have been calculated. The calculation method shall be the same for all data objects of the
@@ -5952,33 +6099,42 @@ pub struct ReadingMmxu {
     /// ‘TRUE_RMS’ and ‘RMS_FUNDAMENTAL’).If the value is 'unspecified', the dependent data objects may be
     /// meaningless.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "ClcMth")]
     pub clc_mth: ::std::option::Option<EngCalcMethodKind>,
     /// Frequency [Hz].
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "Hz")]
     pub hz: ::std::option::Option<Mv>,
     /// Phase to ground/phase to neutral power factors.The power factor is defined as P (active power) /
     /// S (apparent power), so the value range is 0...1. If current (I) and voltage (U) are sinusoidal and
     /// displaced by the angle phi, then the power factor is |cos phi|, again with the value range 0...1.
     /// Therefore, for the power factor per phase, value is contained in 'mag' and 'ang' is not used.
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "PF")]
     pub pf: ::std::option::Option<Wye>,
     /// Sign convention for power factor 'PF' (and reactive power 'VAr').
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "PFSign")]
     pub pf_sign: ::std::option::Option<EngPfSignKind>,
     /// Phase to ground (line) voltages.
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "PhV")]
     pub ph_v: ::std::option::Option<Wye>,
     /// Phase to phase voltages.
     #[prost(message, optional, tag="8")]
+    #[serde(default, rename = "PPV")]
     pub ppv: ::std::option::Option<Del>,
     /// Phase to ground/phase to neutral apparent powers S.
     #[prost(message, optional, tag="9")]
+    #[serde(default, rename = "VA")]
     pub va: ::std::option::Option<Wye>,
     /// Phase to ground/phase to neutral reactive powers Q.
     #[prost(message, optional, tag="10")]
+    #[serde(default, rename = "VAr")]
     pub v_ar: ::std::option::Option<Wye>,
     /// Phase to ground/phase to neutral real powers P.
     #[prost(message, optional, tag="11")]
+    #[serde(default, rename = "W")]
     pub w: ::std::option::Option<Wye>,
 }
 mod reading_mmxu {
@@ -6101,8 +6257,7 @@ impl IsIdentifiedObject for ReadingMmxu {
 }
 /// OpenFMB specialization for breaker, recloser and switch status and event profiles:  LN: Circuit
 /// breaker   Name: XCBR
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct StatusAndEventXcbr {
     /// UML inherited base object
     // parent_message: true
@@ -6112,25 +6267,32 @@ pub struct StatusAndEventXcbr {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForEventAndStatus")]
     pub logical_node_for_event_and_status: ::std::option::Option<LogicalNodeForEventAndStatus>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "DynamicTest")]
     pub dynamic_test: ::std::option::Option<EnsDynamicTestKind>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "Pos")]
     pub pos: ::std::option::Option<PhaseDps>,
     /// Fault latch: LT01=51A OR 51B OR 51C
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "ProtectionPickup")]
     pub protection_pickup: ::std::option::Option<Acd>,
     /// Protection mode such as a group setting or pre-defined curve profile. It is usually pre-defined
     /// by a circuit segment service.
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "ProtectionMode")]
     pub protection_mode: ::std::option::Option<StatusIns>,
     /// Reclose enabled
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "RecloseEnabled")]
     pub reclose_enabled: ::std::option::Option<PhaseSps>,
     /// Reclose mode such idle, cycling and lockout.
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "ReclosingAction")]
     pub reclosing_action: ::std::option::Option<PhaseRecloseAction>,
 }
 mod status_and_event_xcbr {
@@ -6232,11 +6394,11 @@ impl IsIdentifiedObject for StatusAndEventXcbr {
     }
 }
 /// Integer control status
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct StatusInc {
     /// Quality of the value in 'stVal'.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub q: ::std::option::Option<Quality>,
     /// Value of the data.
     // parent_message: false
@@ -6246,9 +6408,11 @@ pub struct StatusInc {
     // uuid: false
     // key: false
     #[prost(int32, tag="2")]
+    #[serde(default, rename = "stVal")]
     pub st_val: i32,
     /// Timestamp of the last change or update event of 'stVal' or the last change of value in 'q'.
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub t: ::std::option::Option<Timestamp>,
 }
 mod status_inc {
@@ -6291,11 +6455,11 @@ impl IsStatusInc for StatusInc {
     }
 }
 /// &lt;&lt;statistics&gt;&gt; Integer controlled step position information (ISC)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct StatusIsc {
     /// Quality of the value in 'valWTr'.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub q: ::std::option::Option<Quality>,
     /// Status value
     // parent_message: false
@@ -6305,9 +6469,11 @@ pub struct StatusIsc {
     // uuid: false
     // key: false
     #[prost(int32, tag="2")]
+    #[serde(default, rename = "stVal")]
     pub st_val: i32,
     /// Timestamp of the last change of the value in any of 'valWTr' or 'q'.
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub t: ::std::option::Option<Timestamp>,
 }
 mod status_isc {
@@ -6350,8 +6516,7 @@ impl IsStatusIsc for StatusIsc {
     }
 }
 /// Generic status message information
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct StatusMessageInfo {
     /// UML inherited base object
     // parent_message: true
@@ -6361,6 +6526,7 @@ pub struct StatusMessageInfo {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "messageInfo")]
     pub message_info: ::std::option::Option<MessageInfo>,
 }
 mod status_message_info {
@@ -6412,11 +6578,11 @@ impl IsIdentifiedObject for StatusMessageInfo {
     }
 }
 /// Controllable single point (SPC)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct StatusSpc {
     /// Quality of the value in 'stVal'.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub q: ::std::option::Option<Quality>,
     /// Status value of the controllable data object.
     // parent_message: false
@@ -6426,9 +6592,11 @@ pub struct StatusSpc {
     // uuid: false
     // key: false
     #[prost(bool, tag="2")]
+    #[serde(default, rename = "stVal")]
     pub st_val: bool,
     /// Timestamp of the last change of the value in any of 'stVal' or 'q'.
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub t: ::std::option::Option<Timestamp>,
 }
 mod status_spc {
@@ -6471,8 +6639,7 @@ impl IsStatusSpc for StatusSpc {
     }
 }
 /// Status value
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct StatusValue {
     /// UML inherited base object
     // parent_message: true
@@ -6482,9 +6649,11 @@ pub struct StatusValue {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<IdentifiedObject>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "modBlk")]
     pub mod_blk: ::std::option::Option<bool>,
 }
 mod status_value {
@@ -6535,11 +6704,11 @@ impl IsIdentifiedObject for StatusValue {
     }
 }
 /// Visible string status (VSS)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Vss {
     /// Quality of the value in 'stVal'.
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub q: ::std::option::Option<Quality>,
     /// Value of the data.
     // parent_message: false
@@ -6549,9 +6718,11 @@ pub struct Vss {
     // uuid: false
     // key: false
     #[prost(string, tag="2")]
+    #[serde(default, rename = "stVal")]
     pub st_val: std::string::String,
     /// Timestamp of the last change of the value in any of 'stVal' or 'q'.
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub t: ::std::option::Option<Timestamp>,
 }
 mod vss {
@@ -6594,8 +6765,7 @@ impl IsVss for Vss {
     }
 }
 /// LN: Generic process I/O   Name: GGIO
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct StringEventAndStatusGgio {
     /// UML inherited base object
     // parent_message: true
@@ -6605,9 +6775,11 @@ pub struct StringEventAndStatusGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNode")]
     pub logical_node: ::std::option::Option<LogicalNode>,
     /// Phase code
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "Phase")]
     pub phase: ::std::option::Option<OptionalPhaseCodeKind>,
     /// String status
     // parent_message: false
@@ -6617,6 +6789,7 @@ pub struct StringEventAndStatusGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "StrIn")]
     pub str_in: ::std::option::Option<Vss>,
 }
 mod string_event_and_status_ggio {
@@ -6682,8 +6855,7 @@ impl IsIdentifiedObject for StringEventAndStatusGgio {
     }
 }
 /// Point definition (Point)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SwitchPoint {
     /// Switch position
     // parent_message: false
@@ -6693,6 +6865,7 @@ pub struct SwitchPoint {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "Pos")]
     pub pos: ::std::option::Option<ControlDpc>,
     /// Start time
     // parent_message: false
@@ -6702,6 +6875,7 @@ pub struct SwitchPoint {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "startTime")]
     pub start_time: ::std::option::Option<ControlTimestamp>,
 }
 mod switch_point {
@@ -6738,8 +6912,7 @@ impl IsSwitchPoint for SwitchPoint {
     }
 }
 /// Curve shape setting (FC=SP) (CSG_SP)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SwitchCsg {
     /// The array with the points specifying a curve shape.
     // parent_message: false
@@ -6749,6 +6922,7 @@ pub struct SwitchCsg {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="1")]
+    #[serde(default, rename = "crvPts")]
     pub crv_pts: ::std::vec::Vec<SwitchPoint>,
 }
 mod switch_csg {
@@ -6777,8 +6951,7 @@ impl IsSwitchCsg for SwitchCsg {
     }
 }
 /// Visible string status (VSS)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Vsc {
     /// [OpenFMB Extension]  String control value.
     // parent_message: false
@@ -6788,6 +6961,7 @@ pub struct Vsc {
     // uuid: false
     // key: false
     #[prost(string, tag="1")]
+    #[serde(default, rename = "ctlVal")]
     pub ctl_val: std::string::String,
 }
 mod vsc {
@@ -6815,10 +6989,10 @@ impl IsVsc for Vsc {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalStateKind {
     #[prost(enumeration="StateKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_state_kind {
@@ -6847,138 +7021,188 @@ impl IsOptionalStateKind for OptionalStateKind {
     }
 }
 /// Reclose action kind such as idle, cycling, or lockout.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum FaultDirectionKind {
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "FaultDirectionKind_unknown")]
     Unknown = 0,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "FaultDirectionKind_forward")]
     Forward = 1,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "FaultDirectionKind_backward")]
     Backward = 2,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "FaultDirectionKind_both")]
     Both = 3,
 }
 /// Reclose action kind such as idle, cycling, or lockout.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum PhaseFaultDirectionKind {
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "PhaseFaultDirectionKind_unknown")]
     Unknown = 0,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "PhaseFaultDirectionKind_forward")]
     Forward = 1,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "PhaseFaultDirectionKind_backward")]
     Backward = 2,
 }
 /// The units defined for usage in the CIM.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum UnitSymbolKind {
     /// Dimension less quantity, e.g. count, per unit, etc.
+    #[serde(rename = "UnitSymbolKind_none")]
     None = 0,
     /// Length in meter.
+    #[serde(rename = "UnitSymbolKind_meter")]
     Meter = 2,
     /// Mass in gram.
+    #[serde(rename = "UnitSymbolKind_gram")]
     Gram = 3,
     /// Current in ampere.
+    #[serde(rename = "UnitSymbolKind_Amp")]
     Amp = 5,
     /// Plane angle in degrees.
+    #[serde(rename = "UnitSymbolKind_deg")]
     Deg = 9,
     /// Plane angle in radians.
+    #[serde(rename = "UnitSymbolKind_rad")]
     Rad = 10,
     /// Relative temperature in degrees Celsius. In the SI unit system the symbol is ºC. Electric charge
     /// is measured in coulomb that has the unit symbol C. To distinguish degree Celsius form coulomb the
     /// symbol used in the UML is degC. Reason for not using ºC is the special character º is difficult to
     /// manage in software.
+    #[serde(rename = "UnitSymbolKind_degC")]
     DegC = 23,
     /// Capacitance in farad.
+    #[serde(rename = "UnitSymbolKind_Farad")]
     Farad = 25,
     /// Time in seconds.
+    #[serde(rename = "UnitSymbolKind_sec")]
     Sec = 27,
     /// Inductance in Henry.
+    #[serde(rename = "UnitSymbolKind_Henry")]
     Henry = 28,
     /// Voltage in volt.
+    #[serde(rename = "UnitSymbolKind_V")]
     V = 29,
     /// Resistance in ohm.
+    #[serde(rename = "UnitSymbolKind_ohm")]
     Ohm = 30,
     /// Energy in joule.
+    #[serde(rename = "UnitSymbolKind_Joule")]
     Joule = 31,
     /// Force in newton.
+    #[serde(rename = "UnitSymbolKind_Newton")]
     Newton = 32,
     /// Frequency in hertz.
+    #[serde(rename = "UnitSymbolKind_Hz")]
     Hz = 33,
     /// Active power in watt.
+    #[serde(rename = "UnitSymbolKind_W")]
     W = 38,
     /// Pressure in pascal (n/m2).
+    #[serde(rename = "UnitSymbolKind_Pa")]
     Pa = 39,
     /// Area in square meters.
+    #[serde(rename = "UnitSymbolKind_m2")]
     M2 = 41,
     /// Conductance in siemens.
+    #[serde(rename = "UnitSymbolKind_Siemens")]
     Siemens = 53,
     /// Apparent power in volt ampere.
+    #[serde(rename = "UnitSymbolKind_VA")]
     Va = 61,
     /// Reactive power in volt ampere reactive.
+    #[serde(rename = "UnitSymbolKind_VAr")]
     VAr = 63,
     /// Power factor
+    #[serde(rename = "UnitSymbolKind_wPerVA")]
     WPerVa = 65,
     /// Apparent energy in volt ampere hours.
+    #[serde(rename = "UnitSymbolKind_VAh")]
     VAh = 71,
     /// Real energy in what hours.
+    #[serde(rename = "UnitSymbolKind_Wh")]
     Wh = 72,
     /// Reactive energy in volt ampere reactive hours.
+    #[serde(rename = "UnitSymbolKind_VArh")]
     VArh = 73,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "UnitSymbolKind_hzPerS")]
     HzPerS = 75,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "UnitSymbolKind_wPerS")]
     WPerS = 81,
     /// Other enum not listed
+    #[serde(rename = "UnitSymbolKind_other")]
     Other = 100,
     /// Amp hour
+    #[serde(rename = "UnitSymbolKind_Ah")]
     Ah = 106,
     /// Time in minutes.
+    #[serde(rename = "UnitSymbolKind_min")]
     Min = 159,
     /// Time in hours.
+    #[serde(rename = "UnitSymbolKind_hour")]
     Hour = 160,
     /// Volume in cubic meters.
+    #[serde(rename = "UnitSymbolKind_m3")]
     M3 = 166,
     /// Watts per square meter
+    #[serde(rename = "UnitSymbolKind_wPerM2")]
     WPerM2 = 179,
     /// Relative temperature in degree fahrenheit.
+    #[serde(rename = "UnitSymbolKind_degF")]
     DegF = 279,
     /// Mile per hour
+    #[serde(rename = "UnitSymbolKind_mph")]
     Mph = 500,
 }
 /// The unit multipliers defined for the CIM.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum UnitMultiplierKind {
     /// No multiplier or equivalently multiply by 1.
+    #[serde(rename = "UnitMultiplierKind_none")]
     None = 0,
     /// Other enum not listed
+    #[serde(rename = "UnitMultiplierKind_other")]
     Other = 1,
     /// Centi 10**-2.
+    #[serde(rename = "UnitMultiplierKind_centi")]
     Centi = 2,
     /// Deci 10**-1.
+    #[serde(rename = "UnitMultiplierKind_deci")]
     Deci = 3,
     /// Giga 10**9.
+    #[serde(rename = "UnitMultiplierKind_Giga")]
     Giga = 4,
     /// Kilo 10**3.
+    #[serde(rename = "UnitMultiplierKind_kilo")]
     Kilo = 5,
     /// Mega 10**6.
+    #[serde(rename = "UnitMultiplierKind_Mega")]
     Mega = 6,
     /// Micro 10**-6.
+    #[serde(rename = "UnitMultiplierKind_micro")]
     Micro = 7,
     /// Milli 10**-3.
+    #[serde(rename = "UnitMultiplierKind_milli")]
     Milli = 8,
     /// Nano 10**-9.
+    #[serde(rename = "UnitMultiplierKind_nano")]
     Nano = 9,
     /// Pico 10**-12.
+    #[serde(rename = "UnitMultiplierKind_pico")]
     Pico = 10,
     /// Tera 10**12.
+    #[serde(rename = "UnitMultiplierKind_Tera")]
     Tera = 11,
 }
 /// Enumeration of phase identifiers. Allows designation of phases for both transmission and
@@ -6987,76 +7211,101 @@ pub enum UnitMultiplierKind {
 /// hot wires that are 180 degrees out of phase, while N refers to the neutral wire. Through single
 /// phase transformer connections, these secondary circuits may be served from one or two of the primary
 /// phases A, B, and C. For three-phase loads, use the A, B, C phase codes instead of s12N.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum PhaseCodeKind {
     /// Not applicable
+    #[serde(rename = "PhaseCodeKind_none")]
     None = 0,
     /// Other enum not listed
+    #[serde(rename = "PhaseCodeKind_other")]
     Other = 1,
     /// Neutral phase.
+    #[serde(rename = "PhaseCodeKind_N")]
     N = 16,
     /// Phase C.
+    #[serde(rename = "PhaseCodeKind_C")]
     C = 32,
     /// Phases C and neutral.
+    #[serde(rename = "PhaseCodeKind_CN")]
     Cn = 33,
     /// Phases A and C.
+    #[serde(rename = "PhaseCodeKind_AC")]
     Ac = 40,
     /// Phases A, C and neutral.
+    #[serde(rename = "PhaseCodeKind_ACN")]
     Acn = 41,
     /// Phase B.
+    #[serde(rename = "PhaseCodeKind_B")]
     B = 64,
     /// Phases B and neutral.
+    #[serde(rename = "PhaseCodeKind_BN")]
     Bn = 65,
     /// Phases B and C.
+    #[serde(rename = "PhaseCodeKind_BC")]
     Bc = 66,
     /// Phases B, C, and neutral.
+    #[serde(rename = "PhaseCodeKind_BCN")]
     Bcn = 97,
     /// Phase A.
+    #[serde(rename = "PhaseCodeKind_A")]
     A = 128,
     /// Phases A and neutral.
+    #[serde(rename = "PhaseCodeKind_AN")]
     An = 129,
     /// Phases A and B.
+    #[serde(rename = "PhaseCodeKind_AB")]
     Ab = 132,
     /// Phases A, B, and neutral.
+    #[serde(rename = "PhaseCodeKind_ABN")]
     Abn = 193,
     /// Phases A, B, and C.
+    #[serde(rename = "PhaseCodeKind_ABC")]
     Abc = 224,
     /// Phases A, B, C, and N.
+    #[serde(rename = "PhaseCodeKind_ABCN")]
     Abcn = 225,
     /// Secondary phase 2.
+    #[serde(rename = "PhaseCodeKind_s2")]
     S2 = 256,
     /// Secondary phase 2 and neutral.
+    #[serde(rename = "PhaseCodeKind_s2N")]
     S2N = 257,
     /// Secondary phase 1.
+    #[serde(rename = "PhaseCodeKind_s1")]
     S1 = 512,
     /// Secondary phase 1 and neutral.
+    #[serde(rename = "PhaseCodeKind_s1N")]
     S1N = 513,
     /// Secondary phase 1 and 2.
+    #[serde(rename = "PhaseCodeKind_s12")]
     S12 = 768,
     /// Secondary phases 1, 2, and neutral.
+    #[serde(rename = "PhaseCodeKind_s12N")]
     S12N = 769,
 }
 /// Validity of the value, as condensed information for the client. In case this value is not
 /// 'good', some reasons may be found in the 'detailQual'.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum ValidityKind {
     /// Supervision function has detected no abnormal condition of either the acquisition function or
     /// the information source.
+    #[serde(rename = "ValidityKind_good")]
     Good = 0,
     /// Supervision function has detected an abnormal condition of the acquisition function or the
     /// information source (missing or non-operating updating devices). The value is not defined under this
     /// condition. It shall be used to indicate to the client that the value may be incorrect and shall not
     /// be used.  EXAMPLE If an input unit detects an oscillation of one input it will mark the related
     /// information as invalid.
+    #[serde(rename = "ValidityKind_invalid")]
     Invalid = 1,
     /// Reserved
+    #[serde(rename = "ValidityKind_reserved")]
     Reserved = 2,
     /// Supervision function has detected any abnormal behaviour. However, the value could still be
     /// valid. It is client's responsibility to determine whether the values should be used.
+    #[serde(rename = "ValidityKind_questionable")]
     Questionable = 3,
 }
 /// (default=process) Defines the source of a value. NOTE 1 Substitution may be done locally or via
@@ -7064,318 +7313,413 @@ pub enum ValidityKind {
 /// There are various means to clear a substitution. As an example, a substitution that was done
 /// following an invalid condition may be cleared automatically if the invalid condition is cleared.
 /// However, this is a local issue and therefore
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum SourceKind {
     /// The value is provided by an input function from the process I/O or is calculated from some
     /// application function.
+    #[serde(rename = "SourceKind_process")]
     Process = 0,
     /// The value is provided by an operator input or by an automatic source.
+    #[serde(rename = "SourceKind_substituted")]
     Substituted = 1,
 }
 /// Validity of the value, as condensed information for the client. In case this value is not
 /// 'good', some reasons may be found in the 'detailQual'.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum TimeAccuracyKind {
     /// Undefined
+    #[serde(rename = "TimeAccuracyKind_UNDEFINED")]
     Undefined = 0,
     /// 10 ms (class T0)
+    #[serde(rename = "TimeAccuracyKind_T0")]
     T0 = 7,
     /// 1 ms (class T1)
+    #[serde(rename = "TimeAccuracyKind_T1")]
     T1 = 10,
     /// 100 us (class T2)
+    #[serde(rename = "TimeAccuracyKind_T2")]
     T2 = 14,
     /// 25 us (class T3)
+    #[serde(rename = "TimeAccuracyKind_T3")]
     T3 = 16,
     /// 4 us (class T4)
+    #[serde(rename = "TimeAccuracyKind_T4")]
     T4 = 18,
     /// 1 us (class T5)
+    #[serde(rename = "TimeAccuracyKind_T5")]
     T5 = 20,
     /// Undefined
+    #[serde(rename = "TimeAccuracyKind_unspecified")]
     Unspecified = 31,
 }
 /// ESS function kind
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum ScheduleParameterKind {
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_none")]
     None = 0,
     /// Other enum not listed
+    #[serde(rename = "ScheduleParameterKind_other")]
     Other = 1,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_A_net_mag")]
     ANetMag = 2,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_A_neut_mag")]
     ANeutMag = 3,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_A_phsA_mag")]
     APhsAMag = 4,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_A_phsB_mag")]
     APhsBMag = 5,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_A_phsC_mag")]
     APhsCMag = 6,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_Hz_mag")]
     HzMag = 7,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PF_net_mag")]
     PfNetMag = 8,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PF_neut_mag")]
     PfNeutMag = 9,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PF_phsA_mag")]
     PfPhsAMag = 10,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PF_phsB_mag")]
     PfPhsBMag = 11,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PF_phsC_mag")]
     PfPhsCMag = 12,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PhV_net_ang")]
     PhVNetAng = 13,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PhV_net_mag")]
     PhVNetMag = 14,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PhV_neut_ang")]
     PhVNeutAng = 15,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PhV_neut_mag")]
     PhVNeutMag = 16,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PhV_phsA_ang")]
     PhVPhsAAng = 17,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PhV_phsA_mag")]
     PhVPhsAMag = 18,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PhV_phsB_ang")]
     PhVPhsBAng = 19,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PhV_phsB_mag")]
     PhVPhsBMag = 20,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PhV_phsC_ang")]
     PhVPhsCAng = 21,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PhV_phsC_mag")]
     PhVPhsCMag = 22,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PPV_phsAB_ang")]
     PpvPhsAbAng = 23,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PPV_phsAB_mag")]
     PpvPhsAbMag = 24,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PPV_phsBC_ang")]
     PpvPhsBcAng = 25,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PPV_phsBC_mag")]
     PpvPhsBcMag = 26,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PPV_phsCA_ang")]
     PpvPhsCaAng = 27,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_PPV_phsCA_mag")]
     PpvPhsCaMag = 28,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_VA_net_mag")]
     VaNetMag = 29,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_VA_neut_mag")]
     VaNeutMag = 30,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_VA_phsA_mag")]
     VaPhsAMag = 31,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_VA_phsB_mag")]
     VaPhsBMag = 32,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_VA_phsC_mag")]
     VaPhsCMag = 33,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_VAr_net_mag")]
     VArNetMag = 34,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_VAr_neut_mag")]
     VArNeutMag = 35,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_VAr_phsA_mag")]
     VArPhsAMag = 36,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_VAr_phsB_mag")]
     VArPhsBMag = 37,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_VAr_phsC_mag")]
     VArPhsCMag = 38,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_W_net_mag")]
     WNetMag = 39,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_W_neut_mag")]
     WNeutMag = 40,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_W_phsA_mag")]
     WPhsAMag = 41,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_W_phsB_mag")]
     WPhsBMag = 42,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ScheduleParameterKind_W_phsC_mag")]
     WPhsCMag = 43,
 }
 /// Calculation method (CalcMethodKind enumeration)
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum CalcMethodKind {
     /// Undefined enum value which can be used for Protobuf generation and be consistent with other
     /// technologies.
+    #[serde(rename = "CalcMethodKind_UNDEFINED")]
     Undefined = 0,
     /// All analogue values (i.e., all common attributes 'i' and 'f') meet the sampling and filtering
     /// characteristics specified in IEEE C37.118.1 for P-CLASS.
+    #[serde(rename = "CalcMethodKind_P_CLASS")]
     PClass = 11,
     /// All analogue values (i.e., all common attributes 'i' and 'f') meet the sampling and filtering
     /// characteristics specified in IEEE C37.118.1 for M-CLASS.
+    #[serde(rename = "CalcMethodKind_M_CLASS")]
     MClass = 12,
     /// All analogue values are [F(t+T)-F(t)] for a calculation interval T (in the same unit as the
     /// original entity). Note: The client can still calculate rate so: RATE = DIFF/T.
+    #[serde(rename = "CalcMethodKind_DIFF")]
     Diff = 13,
 }
 /// Power system connect modes to the power grid (GridConnectModeKind)
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum GridConnectModeKind {
     /// Undefined
+    #[serde(rename = "GridConnectModeKind_UNDEFINED")]
     Undefined = 0,
     /// Current-source inverter (CSI)
+    #[serde(rename = "GridConnectModeKind_CSI")]
     Csi = 1,
     /// Voltage-controlled voltage-source inverter (VC-VSI)
+    #[serde(rename = "GridConnectModeKind_VC_VSI")]
     VcVsi = 2,
     /// Current-controlled voltage-source inverter (CC-VSI)
+    #[serde(rename = "GridConnectModeKind_CC_VSI")]
     CcVsi = 3,
     /// Not applicable / Unknown
+    #[serde(rename = "GridConnectModeKind_none")]
     None = 98,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "GridConnectModeKind_other")]
     Other = 99,
     /// Voltage source inverter regulating to P and Q references (VSI PQ)
+    #[serde(rename = "GridConnectModeKind_VSI_PQ")]
     VsiPq = 2000,
     /// Voltage source inverter regulating to voltage and frequency references paralleling other
     /// generation and not grid forming (VSI VF).
+    #[serde(rename = "GridConnectModeKind_VSI_VF")]
     VsiVf = 2001,
     /// Voltage source inverter regulating to voltage and frequency references as primary grid forming
     /// generation (VSI ISO).
+    #[serde(rename = "GridConnectModeKind_VSI_ISO")]
     VsiIso = 2002,
 }
 /// Power factor sign (PFSignKind enumeration)
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum PfSignKind {
     /// Undefined enum value which can be used for Protobuf generation and be consistent with other
     /// technologies.
+    #[serde(rename = "PFSignKind_UNDEFINED")]
     Undefined = 0,
     /// All analogue values are [F(t+T)-F(t)] for a calculation interval T (in the same unit as the
     /// original entity). Note: The client can still calculate rate so: RATE = DIFF/T.
+    #[serde(rename = "PFSignKind_IEC")]
     Iec = 1,
     /// All analogue values (i.e., all common attributes 'i' and 'f') meet the sampling and filtering
     /// characteristics specified in IEEE C37.118.1 for M-CLASS.
+    #[serde(rename = "PFSignKind_EEI")]
     Eei = 2,
 }
 /// Behaviour or mode (BehaviourModeKind enumeration)
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum BehaviourModeKind {
     /// Undefined
+    #[serde(rename = "BehaviourModeKind_UNDEFINED")]
     Undefined = 0,
     /// Normal enabled state.
+    #[serde(rename = "BehaviourModeKind_on")]
     On = 1,
     /// Process is passively supervised.
+    #[serde(rename = "BehaviourModeKind_blocked")]
     Blocked = 2,
     /// Function is operated but results are indicated as test results.
+    #[serde(rename = "BehaviourModeKind_test")]
     Test = 3,
     /// Function is operated in test mode, but with no impact to the process.
+    #[serde(rename = "BehaviourModeKind_test_blocked")]
     TestBlocked = 4,
     /// Function is inactive but shows its configuration capability.
+    #[serde(rename = "BehaviourModeKind_off")]
     Off = 5,
 }
 /// DER operational state (DERGeneratorStateKind)
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum DerGeneratorStateKind {
     /// Undefined enum value which can be used for Protobuf generation and be consistent with other
     /// technologies.
+    #[serde(rename = "DERGeneratorStateKind_UNDEFINED")]
     Undefined = 0,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "DERGeneratorStateKind_Not_operating")]
     NotOperating = 1,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "DERGeneratorStateKind_Operating")]
     Operating = 2,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "DERGeneratorStateKind_Starting_up")]
     StartingUp = 3,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "DERGeneratorStateKind_Shutting_down")]
     ShuttingDown = 4,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "DERGeneratorStateKind_At_disconnect_level")]
     AtDisconnectLevel = 5,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "DERGeneratorStateKind_Ramping_in_power")]
     RampingInPower = 6,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "DERGeneratorStateKind_Ramping_in_reactive_power")]
     RampingInReactivePower = 7,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "DERGeneratorStateKind_Standby")]
     Standby = 8,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "DERGeneratorStateKind_Not_applicable_Unknown")]
     NotApplicableUnknown = 98,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "DERGeneratorStateKind_Other")]
     Other = 99,
 }
 /// Dynamic test status (see IEC61850-7-2 section 20.2.1 Direct control with normal security, state
 /// machine diagram)   A simplified state machine diagram (from Herb F.) is provided.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum DynamicTestKind {
     /// None
+    #[serde(rename = "DynamicTestKind_none")]
     None = 0,
     /// Testing status
+    #[serde(rename = "DynamicTestKind_testing")]
     Testing = 1,
     /// Operating status
+    #[serde(rename = "DynamicTestKind_operating")]
     Operating = 2,
     /// Failed status
+    #[serde(rename = "DynamicTestKind_failed")]
     Failed = 3,
 }
 /// State kind
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum HealthKind {
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "HealthKind_none")]
     None = 0,
     /// No problems, normal operation ("green").
+    #[serde(rename = "HealthKind_OK")]
     Ok = 1,
     /// Minor problems, but in safe operating mode ("yellow"). The exact meaning is a local issue,
     /// depending on the dedicated function/device.
+    #[serde(rename = "HealthKind_Warning")]
     Warning = 2,
     /// Severe problem, no operation possible ("red").
+    #[serde(rename = "HealthKind_Alarm")]
     Alarm = 3,
 }
 /// MISSING DOCUMENTATION!!!
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum SwitchingCapabilityKind {
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "SwitchingCapabilityKind_none")]
     None = 0,
     /// Open
+    #[serde(rename = "SwitchingCapabilityKind_open")]
     Open = 1,
     /// Close
+    #[serde(rename = "SwitchingCapabilityKind_close")]
     Close = 2,
     /// Open and Close
+    #[serde(rename = "SwitchingCapabilityKind_open_and_close")]
     OpenAndClose = 3,
 }
 /// Double point position status
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum DbPosKind {
     /// Transient status
+    #[serde(rename = "DbPosKind_transient")]
     Transient = 0,
     /// Closed status
+    #[serde(rename = "DbPosKind_closed")]
     Closed = 1,
     /// Open status
+    #[serde(rename = "DbPosKind_open")]
     Open = 2,
     /// Invalid status
+    #[serde(rename = "DbPosKind_invalid")]
     Invalid = 3,
 }
 /// Reclose action kind such as idle, cycling, or lockout.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum RecloseActionKind {
     /// Idle state
+    #[serde(rename = "RecloseActionKind_idle")]
     Idle = 0,
     /// Cycling state
+    #[serde(rename = "RecloseActionKind_cycling")]
     Cycling = 1,
     /// Lockout state
+    #[serde(rename = "RecloseActionKind_lockout")]
     Lockout = 2,
 }
 /// State kind
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum StateKind {
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "StateKind_off")]
     Off = 0,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "StateKind_on")]
     On = 1,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "StateKind_standby")]
     Standby = 2,
 }

--- a/openfmb-messages/src/coordinationservicemodule.rs
+++ b/openfmb-messages/src/coordinationservicemodule.rs
@@ -1,8 +1,8 @@
 use crate::commonmodule::*;
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalCoordinationServiceModeKind {
     #[prost(enumeration="CoordinationServiceModeKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_coordination_service_mode_kind {
@@ -31,8 +31,7 @@ impl IsOptionalCoordinationServiceModeKind for OptionalCoordinationServiceModeKi
     }
 }
 /// Coordination service mode kind
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EngCoordinationServiceModeKind {
     /// The value of the coordination service mode.
     // parent_message: false
@@ -42,9 +41,11 @@ pub struct EngCoordinationServiceModeKind {
     // uuid: false
     // key: false
     #[prost(enumeration="CoordinationServiceModeKind", tag="1")]
+    #[serde(default, rename = "setVal")]
     pub set_val: i32,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "setValExtension")]
     pub set_val_extension: ::std::option::Option<::std::string::String>,
 }
 mod eng_coordination_service_mode_kind {
@@ -81,8 +82,7 @@ impl IsEngCoordinationServiceModeKind for EngCoordinationServiceModeKind {
 }
 /// OpenFMB specialization for coordination service control, DCSC (Distributed Coordination Service
 /// Control), following 61850 naming convention.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CoordinationControlDcsc {
     /// UML inherited base object
     // parent_message: true
@@ -92,12 +92,15 @@ pub struct CoordinationControlDcsc {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForControl")]
     pub logical_node_for_control: ::std::option::Option<super::commonmodule::LogicalNodeForControl>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "CoordinationServiceMode")]
     pub coordination_service_mode: ::std::option::Option<EngCoordinationServiceModeKind>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "Island")]
     pub island: ::std::option::Option<super::commonmodule::ControlDpc>,
 }
 mod coordination_control_dcsc {
@@ -171,8 +174,7 @@ impl IsIdentifiedObject for CoordinationControlDcsc {
     }
 }
 /// Switch discrete control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CoordinationControl {
     /// UML inherited base object
     // parent_message: true
@@ -182,9 +184,11 @@ pub struct CoordinationControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<super::commonmodule::IdentifiedObject>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub check: ::std::option::Option<super::commonmodule::CheckConditions>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -194,6 +198,7 @@ pub struct CoordinationControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "coordinationControlDCSC")]
     pub coordination_control_dcsc: ::std::option::Option<CoordinationControlDcsc>,
 }
 mod coordination_control {
@@ -252,8 +257,7 @@ impl IsIdentifiedObject for CoordinationControl {
 }
 /// Switch control profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CoordinationControlProfile {
     /// UML inherited base object
     // parent_message: true
@@ -263,6 +267,7 @@ pub struct CoordinationControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -272,6 +277,7 @@ pub struct CoordinationControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "applicationSystem")]
     pub application_system: ::std::option::Option<super::commonmodule::ApplicationSystem>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -281,6 +287,7 @@ pub struct CoordinationControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "coordinationControl")]
     pub coordination_control: ::std::option::Option<CoordinationControl>,
 }
 mod coordination_control_profile {
@@ -355,8 +362,7 @@ impl IsIdentifiedObject for CoordinationControlProfile {
 }
 /// OpenFMB specialization for coordination service control, DCSC (Distributed Coordination Service
 /// Control), following 61850 naming convention.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CoordinationEventDcsc {
     /// UML inherited base object
     // parent_message: true
@@ -366,27 +372,35 @@ pub struct CoordinationEventDcsc {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNode")]
     pub logical_node: ::std::option::Option<super::commonmodule::LogicalNode>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "CoordinationServiceMode")]
     pub coordination_service_mode: ::std::option::Option<EngCoordinationServiceModeKind>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "Island")]
     pub island: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "PermissibleAuto")]
     pub permissible_auto: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "PermissibleManual")]
     pub permissible_manual: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "PermissibleNetzero")]
     pub permissible_netzero: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "PermissibleStart")]
     pub permissible_start: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="8")]
+    #[serde(default, rename = "PermissibleStop")]
     pub permissible_stop: ::std::option::Option<super::commonmodule::StatusSps>,
 }
 mod coordination_event_dcsc {
@@ -487,8 +501,7 @@ impl IsIdentifiedObject for CoordinationEventDcsc {
     }
 }
 /// Switch event
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CoordinationEvent {
     /// UML inherited base object
     // parent_message: true
@@ -498,6 +511,7 @@ pub struct CoordinationEvent {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<super::commonmodule::IdentifiedObject>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -507,6 +521,7 @@ pub struct CoordinationEvent {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "coordinationEventDCSC")]
     pub coordination_event_dcsc: ::std::option::Option<CoordinationEventDcsc>,
 }
 mod coordination_event {
@@ -558,8 +573,7 @@ impl IsIdentifiedObject for CoordinationEvent {
 }
 /// Switch event profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CoordinationEventProfile {
     /// UML inherited base object
     // parent_message: true
@@ -569,6 +583,7 @@ pub struct CoordinationEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventMessageInfo")]
     pub event_message_info: ::std::option::Option<super::commonmodule::EventMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -578,6 +593,7 @@ pub struct CoordinationEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "applicationSystem")]
     pub application_system: ::std::option::Option<super::commonmodule::ApplicationSystem>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -587,6 +603,7 @@ pub struct CoordinationEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "coordinationEvent")]
     pub coordination_event: ::std::option::Option<CoordinationEvent>,
 }
 mod coordination_event_profile {
@@ -661,8 +678,7 @@ impl IsIdentifiedObject for CoordinationEventProfile {
 }
 /// OpenFMB specialization for coordination service control, DCSC (Distributed Coordination Service
 /// Control), following 61850 naming convention.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CoordinationStatusDcsc {
     /// UML inherited base object
     // parent_message: true
@@ -672,27 +688,35 @@ pub struct CoordinationStatusDcsc {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNode")]
     pub logical_node: ::std::option::Option<super::commonmodule::LogicalNode>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "CoordinationServiceMode")]
     pub coordination_service_mode: ::std::option::Option<EngCoordinationServiceModeKind>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "Island")]
     pub island: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "PermissibleAuto")]
     pub permissible_auto: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "PermissibleManual")]
     pub permissible_manual: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "PermissibleNetzero")]
     pub permissible_netzero: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "PermissibleStart")]
     pub permissible_start: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="8")]
+    #[serde(default, rename = "PermissibleStop")]
     pub permissible_stop: ::std::option::Option<super::commonmodule::StatusSps>,
 }
 mod coordination_status_dcsc {
@@ -793,8 +817,7 @@ impl IsIdentifiedObject for CoordinationStatusDcsc {
     }
 }
 /// Switch event
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CoordinationStatus {
     /// UML inherited base object
     // parent_message: true
@@ -804,6 +827,7 @@ pub struct CoordinationStatus {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<super::commonmodule::IdentifiedObject>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -813,6 +837,7 @@ pub struct CoordinationStatus {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "coordinationStatusDCSC")]
     pub coordination_status_dcsc: ::std::option::Option<CoordinationStatusDcsc>,
 }
 mod coordination_status {
@@ -864,8 +889,7 @@ impl IsIdentifiedObject for CoordinationStatus {
 }
 /// Switch event profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CoordinationStatusProfile {
     /// UML inherited base object
     // parent_message: true
@@ -875,6 +899,7 @@ pub struct CoordinationStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventMessageInfo")]
     pub event_message_info: ::std::option::Option<super::commonmodule::EventMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -884,6 +909,7 @@ pub struct CoordinationStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "applicationSystem")]
     pub application_system: ::std::option::Option<super::commonmodule::ApplicationSystem>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -893,6 +919,7 @@ pub struct CoordinationStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "coordinationStatus")]
     pub coordination_status: ::std::option::Option<CoordinationStatus>,
 }
 mod coordination_status_profile {
@@ -966,20 +993,25 @@ impl IsIdentifiedObject for CoordinationStatusProfile {
     }
 }
 /// State kind
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum CoordinationServiceModeKind {
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "CoordinationServiceModeKind_none")]
     None = 0,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "CoordinationServiceModeKind_auto")]
     Auto = 1,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "CoordinationServiceModeKind_manual")]
     Manual = 2,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "CoordinationServiceModeKind_netzero")]
     Netzero = 3,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "CoordinationServiceModeKind_start")]
     Start = 4,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "CoordinationServiceModeKind_stop")]
     Stop = 5,
 }

--- a/openfmb-messages/src/essmodule.rs
+++ b/openfmb-messages/src/essmodule.rs
@@ -1,7 +1,6 @@
 use crate::commonmodule::*;
 /// Specialized 61850 ZBAT class  LN: Battery   Name: ZBAT
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssEventZbat {
     /// UML inherited base object
     // parent_message: true
@@ -11,21 +10,27 @@ pub struct EssEventZbat {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForEventAndStatus")]
     pub logical_node_for_event_and_status: ::std::option::Option<super::commonmodule::LogicalNodeForEventAndStatus>,
     /// If true, the battery is in overcharge (voltage or current) condition.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "BatHi")]
     pub bat_hi: ::std::option::Option<super::commonmodule::StatusSps>,
     /// If true, the battery voltage or charge has dropped below a pre-set level.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "BatLo")]
     pub bat_lo: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "BatSt")]
     pub bat_st: ::std::option::Option<super::commonmodule::StatusSps>,
     /// State of charge (in percentage)
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "Soc")]
     pub soc: ::std::option::Option<super::commonmodule::Mv>,
     /// If stVal TRUE, the device is in standby.
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "Stdby")]
     pub stdby: ::std::option::Option<super::commonmodule::StatusSps>,
 }
 mod ess_event_zbat {
@@ -120,44 +125,51 @@ impl IsIdentifiedObject for EssEventZbat {
     }
 }
 /// ESS inverter high level function to maintain frequency within dead bands.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct FrequencyRegulation {
     /// uint/0.01Hz  Frequency regulation is performed when the grid frequency goes beyond the dead
     /// bands. The dead bands are defined as follows: Upper DB = frequency set point + dead band plus Lower
     /// DB = frequency set point – dead band minus
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "frequencyDeadBandMinus")]
     pub frequency_dead_band_minus: ::std::option::Option<f32>,
     /// uint/0.01Hz  Frequency regulation is performed when the grid frequency goes beyond the dead
     /// bands. The dead bands are defined as follows: Upper DB = frequency set point + dead band plus Lower
     /// DB = frequency set point – dead band minus
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "frequencyDeadBandPlus")]
     pub frequency_dead_band_plus: ::std::option::Option<f32>,
     /// Control value (TRUE or FALSE)
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "frequencyRegulationCtl")]
     pub frequency_regulation_ctl: ::std::option::Option<bool>,
     /// uint/0.01Hz  Target frequency
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "frequencySetPoint")]
     pub frequency_set_point: ::std::option::Option<f32>,
     /// uint/0.01Hz  Other modes of operation, such as peak shaving, smoothing or SOC management may
     /// operate if the grid frequency is within the stable band. Upper stable band = frequency set point +
     /// band plus Lower stable band = frequency set point – band minus
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "gridFrequencyStableBandMinus")]
     pub grid_frequency_stable_band_minus: ::std::option::Option<f32>,
     /// uint/0.01Hz  Other modes of operation, such as peak shaving, smoothing or SOC management may
     /// operate if the grid frequency is within the stable band. Upper stable band = frequency set point +
     /// band plus Lower stable band = frequency set point – band minus
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "gridFrequencyStableBandPlus")]
     pub grid_frequency_stable_band_plus: ::std::option::Option<f32>,
     /// uint/0.1%  The droops define the reaction of the PCS to under/over frequency events. A droop of
     /// 1% means that the PCS will output 100% power if the frequency is 1% of the nominal frequency away
     /// from the upper or lower dead band. The minimum droop value possible is 0.8%.
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "overFrequencyDroop")]
     pub over_frequency_droop: ::std::option::Option<f32>,
     /// uint/0.1%  The droops define the reaction of the PCS to under/over voltage events. A droop of 1%
     /// means that the PCS will output 100% power if the voltage is 1% of the nominal voltage away from the
     /// upper or lower dead band. The minimum droop value possible is 0.8%.
     #[prost(message, optional, tag="8")]
+    #[serde(default, rename = "underFrequencyDroop")]
     pub under_frequency_droop: ::std::option::Option<f32>,
 }
 mod frequency_regulation {
@@ -236,26 +248,30 @@ impl IsFrequencyRegulation for FrequencyRegulation {
     }
 }
 /// ESS inverter high level function to maintain power level by charging or discharging
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct PeakShaving {
     /// uint/1kW  If the supervised power goes below this limit, the ESS will charge to maintain this limit.
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "baseShavingLimit")]
     pub base_shaving_limit: ::std::option::Option<f32>,
     /// Control value (TRUE or FALSE)
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "peakShavingCtl")]
     pub peak_shaving_ctl: ::std::option::Option<bool>,
     /// uint/1kW  If the supervised power goes above this limit, the ESS will discharge to maintain this
     /// limit.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "peakShavingLimit")]
     pub peak_shaving_limit: ::std::option::Option<f32>,
     /// uint/1kW  If the supervised power is between the band defined by these two limits then SOC
     /// management is allowed.
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "socManagementAllowedHighLimit")]
     pub soc_management_allowed_high_limit: ::std::option::Option<f32>,
     /// uint/1kW  If the supervised power is between the band defined by these two limits then SOC
     /// management is allowed.
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "socManagementAllowedLowLimit")]
     pub soc_management_allowed_low_limit: ::std::option::Option<f32>,
 }
 mod peak_shaving {
@@ -313,35 +329,39 @@ impl IsPeakShaving for PeakShaving {
     }
 }
 /// ESS inverter high level function to shut down ESS if SOC exceeds high or low limits.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SocLimit {
     /// uint/1%  These limits define the operational range of the battery. If a lineup reaches the SOC
     /// high limit, the inverter’s output is reduced to 0. Charging is then blocked until the hysteresis is
     /// overcome. The same logic applies to the SOC low limit, except that after the ramp down is complete,
     /// discharging is blocked until the hysteresis is overcome.
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "socHighLimit")]
     pub soc_high_limit: ::std::option::Option<f32>,
     /// uint/1%  These limits define the operational range of the battery. If a lineup reaches the SOC
     /// high limit, the inverter’s output is reduced to 0. Charging is then blocked until the hysteresis is
     /// overcome. The same logic applies to the SOC low limit, except that after the ramp down is complete,
     /// discharging is blocked until the hysteresis is overcome.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "socHighLimitHysteresis")]
     pub soc_high_limit_hysteresis: ::std::option::Option<f32>,
     /// Control value (TRUE or FALSE)
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "socLimitCtl")]
     pub soc_limit_ctl: ::std::option::Option<bool>,
     /// uint/1%  These limits define the operational range of the battery. If a lineup reaches the SOC
     /// high limit, the inverter’s output is reduced to 0. Charging is then blocked until the hysteresis is
     /// overcome. The same logic applies to the SOC low limit, except that after the ramp down is complete,
     /// discharging is blocked until the hysteresis is overcome.
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "socLowLimit")]
     pub soc_low_limit: ::std::option::Option<f32>,
     /// uint/1%  These hysteresis define the release conditions for the block charge or discharge
     /// initiated by the SOC limits.For example, assume a SOC low limit of 10% and a SOC low limit
     /// hysteresis of 2% and that discharging is blocked because the batteries SOC reached the SOC low
     /// limit, discharging will only be allowed again after the battery’s SOC reaches 13%.
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "socLowLimitHysteresis")]
     pub soc_low_limit_hysteresis: ::std::option::Option<f32>,
 }
 mod soc_limit {
@@ -399,27 +419,31 @@ impl IsSocLimit for SocLimit {
     }
 }
 /// ESS inverter high level function to maintain SOC within dead bands
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SocManagement {
     /// uint/1%  Define a dead band (DB) around the SOC set point. When the battery SOC goes outside the
     /// dead band, the SOC management executes and bring the SOC back to the set point. Upper DB = set point
     /// + dead band plus Lower DB = set point – dead band minus
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "socDeadBandMinus")]
     pub soc_dead_band_minus: ::std::option::Option<f32>,
     /// uint/1%  Define a dead band (DB) around the SOC set point. When the battery SOC goes outside the
     /// dead band, the SOC management executes and bring the SOC back to the set point. Upper DB = set point
     /// + dead band plus Lower DB = set point – dead band minus
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "socDeadBandPlus")]
     pub soc_dead_band_plus: ::std::option::Option<f32>,
     /// Control value (TRUE or FALSE)
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "socManagementCtl")]
     pub soc_management_ctl: ::std::option::Option<bool>,
     /// uint/1kW  Set point used for SOC maintenance
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "socPowerSetPoint")]
     pub soc_power_set_point: ::std::option::Option<f32>,
     /// uint/1%  SOC Target in percentage (%).
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "socSetPoint")]
     pub soc_set_point: ::std::option::Option<f32>,
 }
 mod soc_management {
@@ -477,33 +501,37 @@ impl IsSocManagement for SocManagement {
     }
 }
 /// Voltage regulation function
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct VoltageRegulation {
     /// uint/0.1%  The droops define the reaction of the PCS to under/over voltage events. A droop of 1%
     /// means that the PCS will output 100% power if the voltage is 1% of the nominal voltage away from the
     /// upper or lower dead band. The minimum droop value possible is 0.8%.
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "overVoltageDroop")]
     pub over_voltage_droop: ::std::option::Option<f32>,
     /// uint/0.1%  The droops define the reaction of the PCS to under/over voltage events. A droop of 1%
     /// means that the PCS will output 100% power if the voltage is 1% of the nominal voltage away from the
     /// upper or lower dead band. The minimum droop value possible is 0.8%.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "underVoltageDroop")]
     pub under_voltage_droop: ::std::option::Option<f32>,
     /// uint/0.1V  Voltage regulation is performed when the grid voltage goes beyond the dead bands. The
     /// dead bands are defined as follows: Upper DB = voltage set point + dead band plus Lower DB = voltage
     /// set point – dead band minus
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "voltageDeadBandMinus")]
     pub voltage_dead_band_minus: ::std::option::Option<f32>,
     /// uint/0.1V  Voltage regulation is performed when the grid voltage goes beyond the dead bands. The
     /// dead bands are defined as follows: Upper DB = voltage set point + dead band plus Lower DB = voltage
     /// set point – dead band minus
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "voltageDeadBandPlus")]
     pub voltage_dead_band_plus: ::std::option::Option<f32>,
     /// uint/0.1V  Other modes of operation, such as peak shaving, smoothing or SOC management may
     /// operate if the grid frequency is within the stable band. Upper stable band = frequency set point +
     /// band plus Lower stable band = frequency set point – band minus
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "voltageSetPoint")]
     pub voltage_set_point: ::std::option::Option<f32>,
 }
 mod voltage_regulation {
@@ -561,14 +589,15 @@ impl IsVoltageRegulation for VoltageRegulation {
     }
 }
 /// ESS inverter high level function to maintain voltage within droop dead bands.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct VoltageDroop {
     /// Control value (TRUE or FALSE)
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "voltageDroopCtl")]
     pub voltage_droop_ctl: ::std::option::Option<bool>,
     /// Voltage regulation
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "voltageRegulation")]
     pub voltage_regulation: ::std::option::Option<VoltageRegulation>,
 }
 mod voltage_droop {
@@ -605,14 +634,15 @@ impl IsVoltageDroop for VoltageDroop {
     }
 }
 /// ESS inverter high level function to maintain voltage within dead bands.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct VoltagePi {
     /// Control value (TRUE or FALSE)
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "voltagePICtl")]
     pub voltage_pi_ctl: ::std::option::Option<bool>,
     /// Voltage regulation
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "voltageRegulation")]
     pub voltage_regulation: ::std::option::Option<VoltageRegulation>,
 }
 mod voltage_pi {
@@ -649,21 +679,23 @@ impl IsVoltagePi for VoltagePi {
     }
 }
 /// ESS inverter high level function to reduce (smooth) charging or discharging rate of change.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct CapacityFirming {
     /// Control value (TRUE or FALSE)
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "capacityFirmingCtl")]
     pub capacity_firming_ctl: ::std::option::Option<bool>,
     /// uint/1kW/min  If the supervised power increases at a rate higher that the rate defined by these
     /// limits, the ESS will discharge/charge at an opposite dp/dt to reduce (smooth) the rate of change at
     /// the PCC
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "limitNegative_dp_dt")]
     pub limit_negative_dp_dt: ::std::option::Option<f32>,
     /// uint/1kW/min  If the supervised power increases at a rate higher that the rate defined by these
     /// limits, the ESS will discharge/charge at an opposite dp/dt to reduce (smooth) the rate of change at
     /// the PCC
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "limitPositive_dp_dt")]
     pub limit_positive_dp_dt: ::std::option::Option<f32>,
 }
 mod capacity_firming {
@@ -707,29 +739,35 @@ impl IsCapacityFirming for CapacityFirming {
     }
 }
 /// ESS inverter high level functions.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssFunction {
     /// ESS inverter high level function to reduce (smooth) charging or discharging rate of change.
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "capacityFirming")]
     pub capacity_firming: ::std::option::Option<CapacityFirming>,
     /// ESS inverter high level function to maintain frequency within dead bands.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "frequencyRegulation")]
     pub frequency_regulation: ::std::option::Option<FrequencyRegulation>,
     /// ESS inverter high level function to maintain power level by charging or discharging
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "peakShaving")]
     pub peak_shaving: ::std::option::Option<PeakShaving>,
     /// ESS inverter high level function to shut down ESS if SOC exceeds high or low limits.
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "socLimit")]
     pub soc_limit: ::std::option::Option<SocLimit>,
     /// ESS inverter high level function to maintain SOC within dead bands
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "socManagement")]
     pub soc_management: ::std::option::Option<SocManagement>,
     /// ESS inverter high level function to maintain voltage within droop dead bands.
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "voltageDroop")]
     pub voltage_droop: ::std::option::Option<VoltageDroop>,
     /// ESS inverter high level function to maintain voltage within dead bands.
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "voltagePI")]
     pub voltage_pi: ::std::option::Option<VoltagePi>,
 }
 mod ess_function {
@@ -801,47 +839,59 @@ impl IsEssFunction for EssFunction {
     }
 }
 /// Point definition (Point)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssPointStatus {
     /// Black start enable
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "blackStartEnabled")]
     pub black_start_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
     /// Enable frequency set point
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "frequencySetPointEnabled")]
     pub frequency_set_point_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
     /// ESS function parameter
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub function: ::std::option::Option<EssFunction>,
     /// Grid connect mode
     #[prost(message, optional, tag="4")]
+    #[serde(default)]
     pub mode: ::std::option::Option<super::commonmodule::EngGridConnectModeKind>,
     /// Black start enable
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "pctHzDroop")]
     pub pct_hz_droop: ::std::option::Option<f32>,
     /// Black start enable
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "pctVDroop")]
     pub pct_v_droop: ::std::option::Option<f32>,
     /// Ramp rates
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "rampRates")]
     pub ramp_rates: ::std::option::Option<super::commonmodule::RampRate>,
     /// Enable reactive power set point
     #[prost(message, optional, tag="8")]
+    #[serde(default, rename = "reactivePwrSetPointEnabled")]
     pub reactive_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
     /// Enable real power set point
     #[prost(message, optional, tag="9")]
+    #[serde(default, rename = "realPwrSetPointEnabled")]
     pub real_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
     /// ESS state
     #[prost(message, optional, tag="10")]
+    #[serde(default)]
     pub state: ::std::option::Option<super::commonmodule::OptionalStateKind>,
     /// Synchronize back to grid
     #[prost(message, optional, tag="11")]
+    #[serde(default, rename = "syncBackToGrid")]
     pub sync_back_to_grid: ::std::option::Option<super::commonmodule::StatusDps>,
     /// Transition to island on grid loss enable
     #[prost(message, optional, tag="12")]
+    #[serde(default, rename = "transToIslndOnGridLossEnabled")]
     pub trans_to_islnd_on_grid_loss_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
     /// Enable voltage set point
     #[prost(message, optional, tag="13")]
+    #[serde(default, rename = "voltageSetPointEnabled")]
     pub voltage_set_point_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
 }
 mod ess_point_status {
@@ -955,8 +1005,7 @@ impl IsEssPointStatus for EssPointStatus {
     }
 }
 /// Specialized 61850 ZGEN class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssEventAndStatusZgen {
     /// UML inherited base object
     // parent_message: true
@@ -966,21 +1015,27 @@ pub struct EssEventAndStatusZgen {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForEventAndStatus")]
     pub logical_node_for_event_and_status: ::std::option::Option<super::commonmodule::LogicalNodeForEventAndStatus>,
     /// DC Power On/Off Status; True = DC power on
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "AuxPwrSt")]
     pub aux_pwr_st: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "DynamicTest")]
     pub dynamic_test: ::std::option::Option<super::commonmodule::EnsDynamicTestKind>,
     /// Emergency stop
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "EmgStop")]
     pub emg_stop: ::std::option::Option<super::commonmodule::StatusSps>,
     /// Generator is synchronized to EPS, or not; True = Synchronized
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "GnSynSt")]
     pub gn_syn_st: ::std::option::Option<super::commonmodule::StatusSps>,
     /// Point status
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "PointStatus")]
     pub point_status: ::std::option::Option<EssPointStatus>,
 }
 mod ess_event_and_status_zgen {
@@ -1075,8 +1130,7 @@ impl IsIdentifiedObject for EssEventAndStatusZgen {
     }
 }
 /// Specialized 61850 ZGEN class for ESS event profile
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssEventZgen {
     /// UML inherited base object
     // parent_message: true
@@ -1086,6 +1140,7 @@ pub struct EssEventZgen {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eSSEventAndStatusZGEN")]
     pub e_ss_event_and_status_zgen: ::std::option::Option<EssEventAndStatusZgen>,
 }
 mod ess_event_zgen {
@@ -1153,8 +1208,7 @@ impl IsIdentifiedObject for EssEventZgen {
     }
 }
 /// ESS event
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssEvent {
     /// UML inherited base object
     // parent_message: true
@@ -1164,12 +1218,15 @@ pub struct EssEvent {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventValue")]
     pub event_value: ::std::option::Option<super::commonmodule::EventValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "essEventZBAT")]
     pub ess_event_zbat: ::std::option::Option<EssEventZbat>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "essEventZGEN")]
     pub ess_event_zgen: ::std::option::Option<EssEventZgen>,
 }
 mod ess_event {
@@ -1236,8 +1293,7 @@ impl IsIdentifiedObject for EssEvent {
 }
 /// ESS event profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssEventProfile {
     /// UML inherited base object
     // parent_message: true
@@ -1247,6 +1303,7 @@ pub struct EssEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventMessageInfo")]
     pub event_message_info: ::std::option::Option<super::commonmodule::EventMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1256,6 +1313,7 @@ pub struct EssEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub ess: ::std::option::Option<super::commonmodule::Ess>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1265,6 +1323,7 @@ pub struct EssEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "essEvent")]
     pub ess_event: ::std::option::Option<EssEvent>,
 }
 mod ess_event_profile {
@@ -1338,8 +1397,7 @@ impl IsIdentifiedObject for EssEventProfile {
     }
 }
 /// ESS reading value
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssReading {
     /// UML inherited base object
     // parent_message: true
@@ -1349,15 +1407,19 @@ pub struct EssReading {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipmentTerminalReading")]
     pub conducting_equipment_terminal_reading: ::std::option::Option<super::commonmodule::ConductingEquipmentTerminalReading>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phaseMMTN")]
     pub phase_mmtn: ::std::option::Option<super::commonmodule::PhaseMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "readingMMTR")]
     pub reading_mmtr: ::std::option::Option<super::commonmodule::ReadingMmtr>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "readingMMXU")]
     pub reading_mmxu: ::std::option::Option<super::commonmodule::ReadingMmxu>,
 }
 mod ess_reading {
@@ -1423,8 +1485,7 @@ impl IsConductingEquipmentTerminalReading for EssReading {
 }
 /// ESS reading profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssReadingProfile {
     /// UML inherited base object
     // parent_message: true
@@ -1434,6 +1495,7 @@ pub struct EssReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "readingMessageInfo")]
     pub reading_message_info: ::std::option::Option<super::commonmodule::ReadingMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1443,6 +1505,7 @@ pub struct EssReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub ess: ::std::option::Option<super::commonmodule::Ess>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1452,6 +1515,7 @@ pub struct EssReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "essReading")]
     pub ess_reading: ::std::option::Option<EssReading>,
 }
 mod ess_reading_profile {
@@ -1525,8 +1589,7 @@ impl IsIdentifiedObject for EssReadingProfile {
     }
 }
 /// Specialized 61850 ZBAT
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssStatusZbat {
     /// UML inherited base object
     // parent_message: true
@@ -1536,18 +1599,23 @@ pub struct EssStatusZbat {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForEventAndStatus")]
     pub logical_node_for_event_and_status: ::std::option::Option<super::commonmodule::LogicalNodeForEventAndStatus>,
     /// Battery system status &ndash; True: on
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "BatSt")]
     pub bat_st: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "GriMod")]
     pub gri_mod: ::std::option::Option<super::commonmodule::EngGridConnectModeKind>,
     /// State of charge (in percentage)
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "Soc")]
     pub soc: ::std::option::Option<super::commonmodule::Mv>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "Stdby")]
     pub stdby: ::std::option::Option<super::commonmodule::StatusSps>,
 }
 mod ess_status_zbat {
@@ -1635,8 +1703,7 @@ impl IsIdentifiedObject for EssStatusZbat {
     }
 }
 /// Specialized 61850 ZGEN class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssStatusZgen {
     /// UML inherited base object
     // parent_message: true
@@ -1646,6 +1713,7 @@ pub struct EssStatusZgen {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eSSEventAndStatusZGEN")]
     pub e_ss_event_and_status_zgen: ::std::option::Option<EssEventAndStatusZgen>,
 }
 mod ess_status_zgen {
@@ -1713,8 +1781,7 @@ impl IsIdentifiedObject for EssStatusZgen {
     }
 }
 /// ESS status
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssStatus {
     /// UML inherited base object
     // parent_message: true
@@ -1724,12 +1791,15 @@ pub struct EssStatus {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusValue")]
     pub status_value: ::std::option::Option<super::commonmodule::StatusValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "essStatusZBAT")]
     pub ess_status_zbat: ::std::option::Option<EssStatusZbat>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "essStatusZGEN")]
     pub ess_status_zgen: ::std::option::Option<EssStatusZgen>,
 }
 mod ess_status {
@@ -1796,8 +1866,7 @@ impl IsIdentifiedObject for EssStatus {
 }
 /// ESS status profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssStatusProfile {
     /// UML inherited base object
     // parent_message: true
@@ -1807,6 +1876,7 @@ pub struct EssStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusMessageInfo")]
     pub status_message_info: ::std::option::Option<super::commonmodule::StatusMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1816,6 +1886,7 @@ pub struct EssStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub ess: ::std::option::Option<super::commonmodule::Ess>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1825,6 +1896,7 @@ pub struct EssStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "essStatus")]
     pub ess_status: ::std::option::Option<EssStatus>,
 }
 mod ess_status_profile {
@@ -1898,50 +1970,63 @@ impl IsIdentifiedObject for EssStatusProfile {
     }
 }
 /// Point definition (Point)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssPoint {
     /// Black start enable
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "blackStartEnabled")]
     pub black_start_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Enable frequency set point
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "frequencySetPointEnabled")]
     pub frequency_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// ESS function parameter
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub function: ::std::option::Option<EssFunction>,
     /// Grid connect mode
     #[prost(message, optional, tag="4")]
+    #[serde(default)]
     pub mode: ::std::option::Option<super::commonmodule::EngGridConnectModeKind>,
     /// Black start enable
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "pctHzDroop")]
     pub pct_hz_droop: ::std::option::Option<f32>,
     /// Black start enable
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "pctVDroop")]
     pub pct_v_droop: ::std::option::Option<f32>,
     /// Ramp rates
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "rampRates")]
     pub ramp_rates: ::std::option::Option<super::commonmodule::RampRate>,
     /// Enable reactive power set point
     #[prost(message, optional, tag="8")]
+    #[serde(default, rename = "reactivePwrSetPointEnabled")]
     pub reactive_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Enable real power set point
     #[prost(message, optional, tag="9")]
+    #[serde(default, rename = "realPwrSetPointEnabled")]
     pub real_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Reset device
     #[prost(message, optional, tag="10")]
+    #[serde(default)]
     pub reset: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// ESS state
     #[prost(message, optional, tag="11")]
+    #[serde(default)]
     pub state: ::std::option::Option<super::commonmodule::OptionalStateKind>,
     /// Synchronize back to grid
     #[prost(message, optional, tag="12")]
+    #[serde(default, rename = "syncBackToGrid")]
     pub sync_back_to_grid: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Transition to island on grid loss enable
     #[prost(message, optional, tag="13")]
+    #[serde(default, rename = "transToIslndOnGridLossEnabled")]
     pub trans_to_islnd_on_grid_loss_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Enable voltage set point
     #[prost(message, optional, tag="14")]
+    #[serde(default, rename = "voltageSetPointEnabled")]
     pub voltage_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Start time
     // parent_message: false
@@ -1951,6 +2036,7 @@ pub struct EssPoint {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="15")]
+    #[serde(default, rename = "startTime")]
     pub start_time: ::std::option::Option<super::commonmodule::ControlTimestamp>,
 }
 mod ess_point {
@@ -2078,8 +2164,7 @@ impl IsEssPoint for EssPoint {
     }
 }
 /// Curve shape setting (FC=SP) (CSG_SP)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Esscsg {
     /// The array with the points specifying a curve shape.
     // parent_message: false
@@ -2089,6 +2174,7 @@ pub struct Esscsg {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="1")]
+    #[serde(default, rename = "crvPts")]
     pub crv_pts: ::std::vec::Vec<EssPoint>,
 }
 mod esscsg {
@@ -2117,8 +2203,7 @@ impl IsEsscsg for Esscsg {
     }
 }
 /// OpenFMB specialization for control schedule using:  LN: Schedule   Name: FSCH
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssControlScheduleFsch {
     /// Discrete value in ESSCSG type
     // parent_message: false
@@ -2128,6 +2213,7 @@ pub struct EssControlScheduleFsch {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "ValDCSG")]
     pub val_dcsg: ::std::option::Option<Esscsg>,
 }
 mod ess_control_schedule_fsch {
@@ -2157,8 +2243,7 @@ impl IsEssControlScheduleFsch for EssControlScheduleFsch {
     }
 }
 /// Specialized 61850 FSCC class.  LN: Schedule controller   Name: FSCC
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssControlFscc {
     /// UML inherited base object
     // parent_message: true
@@ -2168,9 +2253,11 @@ pub struct EssControlFscc {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlFSCC")]
     pub control_fscc: ::std::option::Option<super::commonmodule::ControlFscc>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "essControlScheduleFSCH")]
     pub ess_control_schedule_fsch: ::std::option::Option<EssControlScheduleFsch>,
 }
 mod ess_control_fscc {
@@ -2245,8 +2332,7 @@ impl IsIdentifiedObject for EssControlFscc {
     }
 }
 /// ESS control class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssControl {
     /// UML inherited base object
     // parent_message: true
@@ -2256,12 +2342,15 @@ pub struct EssControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlValue")]
     pub control_value: ::std::option::Option<super::commonmodule::ControlValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub check: ::std::option::Option<super::commonmodule::CheckConditions>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "essControlFSCC")]
     pub ess_control_fscc: ::std::option::Option<EssControlFscc>,
 }
 mod ess_control {
@@ -2328,8 +2417,7 @@ impl IsIdentifiedObject for EssControl {
 }
 /// ESS control profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct EssControlProfile {
     /// UML inherited base object
     // parent_message: true
@@ -2339,6 +2427,7 @@ pub struct EssControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -2348,6 +2437,7 @@ pub struct EssControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub ess: ::std::option::Option<super::commonmodule::Ess>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -2357,6 +2447,7 @@ pub struct EssControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "essControl")]
     pub ess_control: ::std::option::Option<EssControl>,
 }
 mod ess_control_profile {

--- a/openfmb-messages/src/generationmodule.rs
+++ b/openfmb-messages/src/generationmodule.rs
@@ -1,43 +1,54 @@
 use crate::commonmodule::*;
 /// Point definition (Point)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationPoint {
     /// Black start enable
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "blackStartEnabled")]
     pub black_start_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Enable frequency set point
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "frequencySetPointEnabled")]
     pub frequency_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Black start enable
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "pctHzDroop")]
     pub pct_hz_droop: ::std::option::Option<f32>,
     /// Black start enable
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "pctVDroop")]
     pub pct_v_droop: ::std::option::Option<f32>,
     /// Ramp rates
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "rampRates")]
     pub ramp_rates: ::std::option::Option<super::commonmodule::RampRate>,
     /// Enable reactive power set point
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "reactivePwrSetPointEnabled")]
     pub reactive_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Enable joint real power set point
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "realPwrSetPointEnabled")]
     pub real_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Reset device
     #[prost(message, optional, tag="8")]
+    #[serde(default)]
     pub reset: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// ESS state
     #[prost(message, optional, tag="9")]
+    #[serde(default)]
     pub state: ::std::option::Option<super::commonmodule::OptionalStateKind>,
     /// Synchronize back to grid
     #[prost(message, optional, tag="10")]
+    #[serde(default, rename = "syncBackToGrid")]
     pub sync_back_to_grid: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Transition to island on grid loss enable
     #[prost(message, optional, tag="11")]
+    #[serde(default, rename = "transToIslndOnGridLossEnabled")]
     pub trans_to_islnd_on_grid_loss_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Enable voltage set point
     #[prost(message, optional, tag="12")]
+    #[serde(default, rename = "voltageSetPointEnabled")]
     pub voltage_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Start time
     // parent_message: false
@@ -47,6 +58,7 @@ pub struct GenerationPoint {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="13")]
+    #[serde(default, rename = "startTime")]
     pub start_time: ::std::option::Option<super::commonmodule::ControlTimestamp>,
 }
 mod generation_point {
@@ -160,8 +172,7 @@ impl IsGenerationPoint for GenerationPoint {
     }
 }
 /// Curve shape setting (FC=SP) (CSG_SP)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationCsg {
     /// The array with the points specifying a curve shape.
     // parent_message: false
@@ -171,6 +182,7 @@ pub struct GenerationCsg {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="1")]
+    #[serde(default, rename = "crvPts")]
     pub crv_pts: ::std::vec::Vec<GenerationPoint>,
 }
 mod generation_csg {
@@ -199,8 +211,7 @@ impl IsGenerationCsg for GenerationCsg {
     }
 }
 /// OpenFMB specialization for control schedule using:  LN: Schedule   Name: FSCH
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationControlScheduleFsch {
     /// Discrete value in GenerationCSG type
     // parent_message: false
@@ -210,6 +221,7 @@ pub struct GenerationControlScheduleFsch {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "ValDCSG")]
     pub val_dcsg: ::std::option::Option<GenerationCsg>,
 }
 mod generation_control_schedule_fsch {
@@ -239,8 +251,7 @@ impl IsGenerationControlScheduleFsch for GenerationControlScheduleFsch {
     }
 }
 /// LN: Schedule controller   Name: FSCC
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationControlFscc {
     /// UML inherited base object
     // parent_message: true
@@ -250,9 +261,11 @@ pub struct GenerationControlFscc {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlFSCC")]
     pub control_fscc: ::std::option::Option<super::commonmodule::ControlFscc>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "GenerationControlScheduleFSCH")]
     pub generation_control_schedule_fsch: ::std::option::Option<GenerationControlScheduleFsch>,
 }
 mod generation_control_fscc {
@@ -327,8 +340,7 @@ impl IsIdentifiedObject for GenerationControlFscc {
     }
 }
 /// Generation control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationControl {
     /// UML inherited base object
     // parent_message: true
@@ -338,12 +350,15 @@ pub struct GenerationControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlValue")]
     pub control_value: ::std::option::Option<super::commonmodule::ControlValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub check: ::std::option::Option<super::commonmodule::CheckConditions>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "generationControlFSCC")]
     pub generation_control_fscc: ::std::option::Option<GenerationControlFscc>,
 }
 mod generation_control {
@@ -412,8 +427,7 @@ impl IsIdentifiedObject for GenerationControl {
 /// power. For example, individual machines within a set may be defined for scheduling purposes while a
 /// single control signal is derived for the set. In this case there would be a GeneratingUnit for each
 /// member of the set and an additional GeneratingUnit corresponding to the set.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GeneratingUnit {
     /// UML inherited base object
     // parent_message: true
@@ -423,9 +437,11 @@ pub struct GeneratingUnit {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipment")]
     pub conducting_equipment: ::std::option::Option<super::commonmodule::ConductingEquipment>,
     /// This is the maximum operating active power limit the dispatcher can enter for this unit.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "maxOperatingP")]
     pub max_operating_p: ::std::option::Option<super::commonmodule::ActivePower>,
 }
 mod generating_unit {
@@ -485,8 +501,7 @@ impl IsNamedObject for GeneratingUnit {
 }
 /// Generation control profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationControlProfile {
     /// UML inherited base object
     // parent_message: true
@@ -496,6 +511,7 @@ pub struct GenerationControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -505,6 +521,7 @@ pub struct GenerationControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "generatingUnit")]
     pub generating_unit: ::std::option::Option<GeneratingUnit>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -514,6 +531,7 @@ pub struct GenerationControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "generationControl")]
     pub generation_control: ::std::option::Option<GenerationControl>,
 }
 mod generation_control_profile {
@@ -586,10 +604,10 @@ impl IsIdentifiedObject for GenerationControlProfile {
         self.parent_mut().parent_mut().parent_mut()
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalRealPowerControlKind {
     #[prost(enumeration="RealPowerControlKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_real_power_control_kind {
@@ -618,14 +636,15 @@ impl IsOptionalRealPowerControlKind for OptionalRealPowerControlKind {
     }
 }
 /// Generation discrete control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct DroopParameter {
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub slope: ::std::option::Option<f32>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "unloadedOffset")]
     pub unloaded_offset: ::std::option::Option<f32>,
 }
 mod droop_parameter {
@@ -662,20 +681,23 @@ impl IsDroopParameter for DroopParameter {
     }
 }
 /// Generation real power control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RealPowerControl {
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "droopSetpoint")]
     pub droop_setpoint: ::std::option::Option<DroopParameter>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "isochronousSetpoint")]
     pub isochronous_setpoint: ::std::option::Option<f32>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "realPowerControlMode")]
     pub real_power_control_mode: ::std::option::Option<OptionalRealPowerControlKind>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "realPowerSetpoint")]
     pub real_power_setpoint: ::std::option::Option<f32>,
 }
 mod real_power_control {
@@ -725,10 +747,10 @@ impl IsRealPowerControl for RealPowerControl {
         self
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct OptionalReactivePowerControlKind {
     #[prost(enumeration="ReactivePowerControlKind", tag="1")]
+    #[serde(default)]
     pub value: i32,
 }
 mod optional_reactive_power_control_kind {
@@ -757,23 +779,27 @@ impl IsOptionalReactivePowerControlKind for OptionalReactivePowerControlKind {
     }
 }
 /// Generation real power control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ReactivePowerControl {
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "droopSetpoint")]
     pub droop_setpoint: ::std::option::Option<DroopParameter>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "powerFactorSetpoint")]
     pub power_factor_setpoint: ::std::option::Option<f32>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "reactivePowerControlMode")]
     pub reactive_power_control_mode: ::std::option::Option<OptionalReactivePowerControlKind>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "reactivePowerSetpoint")]
     pub reactive_power_setpoint: ::std::option::Option<f32>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "voltageSetpoint")]
     pub voltage_setpoint: ::std::option::Option<f32>,
 }
 mod reactive_power_control {
@@ -831,8 +857,7 @@ impl IsReactivePowerControl for ReactivePowerControl {
     }
 }
 /// Generation discrete control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationDiscreteControl {
     /// UML inherited base object
     // parent_message: true
@@ -842,15 +867,19 @@ pub struct GenerationDiscreteControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlValue")]
     pub control_value: ::std::option::Option<super::commonmodule::ControlValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub check: ::std::option::Option<super::commonmodule::CheckConditions>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "ReactivePowerControl")]
     pub reactive_power_control: ::std::option::Option<ReactivePowerControl>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "RealPowerControl")]
     pub real_power_control: ::std::option::Option<RealPowerControl>,
 }
 mod generation_discrete_control {
@@ -924,8 +953,7 @@ impl IsIdentifiedObject for GenerationDiscreteControl {
 }
 /// Generation discrete control profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationDiscreteControlProfile {
     /// UML inherited base object
     // parent_message: true
@@ -935,6 +963,7 @@ pub struct GenerationDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -944,6 +973,7 @@ pub struct GenerationDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "generatingUnit")]
     pub generating_unit: ::std::option::Option<GeneratingUnit>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -953,6 +983,7 @@ pub struct GenerationDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "generationDiscreteControl")]
     pub generation_discrete_control: ::std::option::Option<GenerationDiscreteControl>,
 }
 mod generation_discrete_control_profile {
@@ -1026,8 +1057,7 @@ impl IsIdentifiedObject for GenerationDiscreteControlProfile {
     }
 }
 /// Generation reading value
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationReading {
     /// UML inherited base object
     // parent_message: true
@@ -1037,15 +1067,19 @@ pub struct GenerationReading {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipmentTerminalReading")]
     pub conducting_equipment_terminal_reading: ::std::option::Option<super::commonmodule::ConductingEquipmentTerminalReading>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phaseMMTN")]
     pub phase_mmtn: ::std::option::Option<super::commonmodule::PhaseMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "readingMMTR")]
     pub reading_mmtr: ::std::option::Option<super::commonmodule::ReadingMmtr>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "readingMMXU")]
     pub reading_mmxu: ::std::option::Option<super::commonmodule::ReadingMmxu>,
 }
 mod generation_reading {
@@ -1111,8 +1145,7 @@ impl IsConductingEquipmentTerminalReading for GenerationReading {
 }
 /// Generation reading profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationReadingProfile {
     /// UML inherited base object
     // parent_message: true
@@ -1122,6 +1155,7 @@ pub struct GenerationReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "readingMessageInfo")]
     pub reading_message_info: ::std::option::Option<super::commonmodule::ReadingMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1131,6 +1165,7 @@ pub struct GenerationReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "generatingUnit")]
     pub generating_unit: ::std::option::Option<GeneratingUnit>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1140,6 +1175,7 @@ pub struct GenerationReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "generationReading")]
     pub generation_reading: ::std::option::Option<GenerationReading>,
 }
 mod generation_reading_profile {
@@ -1213,41 +1249,51 @@ impl IsIdentifiedObject for GenerationReadingProfile {
     }
 }
 /// Point definition (Point)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationPointStatus {
     /// Black start enable
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "blackStartEnabled")]
     pub black_start_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
     /// Enable frequency set point
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "frequencySetPointEnabled")]
     pub frequency_set_point_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
     /// Black start enable
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "pctHzDroop")]
     pub pct_hz_droop: ::std::option::Option<f32>,
     /// Black start enable
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "pctVDroop")]
     pub pct_v_droop: ::std::option::Option<f32>,
     /// Ramp rates
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "rampRates")]
     pub ramp_rates: ::std::option::Option<super::commonmodule::RampRate>,
     /// Enable reactive power set point
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "reactivePwrSetPointEnabled")]
     pub reactive_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
     /// Enable real power set point
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "realPwrSetPointEnabled")]
     pub real_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
     /// ESS state
     #[prost(message, optional, tag="8")]
+    #[serde(default)]
     pub state: ::std::option::Option<super::commonmodule::OptionalStateKind>,
     /// Synchronize back to grid
     #[prost(message, optional, tag="9")]
+    #[serde(default, rename = "syncBackToGrid")]
     pub sync_back_to_grid: ::std::option::Option<super::commonmodule::StatusDps>,
     /// Transition to island on grid loss enable
     #[prost(message, optional, tag="10")]
+    #[serde(default, rename = "transToIslndOnGridLossEnabled")]
     pub trans_to_islnd_on_grid_loss_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
     /// Enable voltage set point
     #[prost(message, optional, tag="11")]
+    #[serde(default, rename = "voltageSetPointEnabled")]
     pub voltage_set_point_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
 }
 mod generation_point_status {
@@ -1347,8 +1393,7 @@ impl IsGenerationPointStatus for GenerationPointStatus {
     }
 }
 /// Specialized 61850 ZGEN class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationEventAndStatusZgen {
     /// UML inherited base object
     // parent_message: true
@@ -1358,21 +1403,27 @@ pub struct GenerationEventAndStatusZgen {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForEventAndStatus")]
     pub logical_node_for_event_and_status: ::std::option::Option<super::commonmodule::LogicalNodeForEventAndStatus>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "AuxPwrSt")]
     pub aux_pwr_st: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "DynamicTest")]
     pub dynamic_test: ::std::option::Option<super::commonmodule::EnsDynamicTestKind>,
     /// Emergency stop
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "EmgStop")]
     pub emg_stop: ::std::option::Option<super::commonmodule::StatusSps>,
     /// Generator is synchronized to EPS, or not; True = Synchronized
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "GnSynSt")]
     pub gn_syn_st: ::std::option::Option<super::commonmodule::StatusSps>,
     /// Point status
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "PointStatus")]
     pub point_status: ::std::option::Option<GenerationPointStatus>,
 }
 mod generation_event_and_status_zgen {
@@ -1467,8 +1518,7 @@ impl IsIdentifiedObject for GenerationEventAndStatusZgen {
     }
 }
 /// Specialized generation event ZGEN
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationEventZgen {
     /// UML inherited base object
     // parent_message: true
@@ -1478,6 +1528,7 @@ pub struct GenerationEventZgen {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "generationEventAndStatusZGEN")]
     pub generation_event_and_status_zgen: ::std::option::Option<GenerationEventAndStatusZgen>,
 }
 mod generation_event_zgen {
@@ -1545,8 +1596,7 @@ impl IsIdentifiedObject for GenerationEventZgen {
     }
 }
 /// Generation event
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationEvent {
     /// UML inherited base object
     // parent_message: true
@@ -1556,9 +1606,11 @@ pub struct GenerationEvent {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventValue")]
     pub event_value: ::std::option::Option<super::commonmodule::EventValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "generationEventZGEN")]
     pub generation_event_zgen: ::std::option::Option<GenerationEventZgen>,
 }
 mod generation_event {
@@ -1618,8 +1670,7 @@ impl IsIdentifiedObject for GenerationEvent {
 }
 /// Generation event profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationEventProfile {
     /// UML inherited base object
     // parent_message: true
@@ -1629,6 +1680,7 @@ pub struct GenerationEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventMessageInfo")]
     pub event_message_info: ::std::option::Option<super::commonmodule::EventMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1638,6 +1690,7 @@ pub struct GenerationEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "generatingUnit")]
     pub generating_unit: ::std::option::Option<GeneratingUnit>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1647,6 +1700,7 @@ pub struct GenerationEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "generationEvent")]
     pub generation_event: ::std::option::Option<GenerationEvent>,
 }
 mod generation_event_profile {
@@ -1720,8 +1774,7 @@ impl IsIdentifiedObject for GenerationEventProfile {
     }
 }
 /// Specialized 61850 ZGEN class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationStatusZgen {
     /// UML inherited base object
     // parent_message: true
@@ -1731,6 +1784,7 @@ pub struct GenerationStatusZgen {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "generationEventAndStatusZGEN")]
     pub generation_event_and_status_zgen: ::std::option::Option<GenerationEventAndStatusZgen>,
 }
 mod generation_status_zgen {
@@ -1798,8 +1852,7 @@ impl IsIdentifiedObject for GenerationStatusZgen {
     }
 }
 /// Generation status
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationStatus {
     /// UML inherited base object
     // parent_message: true
@@ -1809,9 +1862,11 @@ pub struct GenerationStatus {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusValue")]
     pub status_value: ::std::option::Option<super::commonmodule::StatusValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "generationStatusZGEN")]
     pub generation_status_zgen: ::std::option::Option<GenerationStatusZgen>,
 }
 mod generation_status {
@@ -1871,8 +1926,7 @@ impl IsIdentifiedObject for GenerationStatus {
 }
 /// Generation status profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct GenerationStatusProfile {
     /// UML inherited base object
     // parent_message: true
@@ -1882,6 +1936,7 @@ pub struct GenerationStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusMessageInfo")]
     pub status_message_info: ::std::option::Option<super::commonmodule::StatusMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1891,6 +1946,7 @@ pub struct GenerationStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "generatingUnit")]
     pub generating_unit: ::std::option::Option<GeneratingUnit>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1900,6 +1956,7 @@ pub struct GenerationStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "generationStatus")]
     pub generation_status: ::std::option::Option<GenerationStatus>,
 }
 mod generation_status_profile {
@@ -1973,36 +2030,45 @@ impl IsIdentifiedObject for GenerationStatusProfile {
     }
 }
 /// Real power control kind
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum RealPowerControlKind {
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "RealPowerControlKind_UNDEFINED")]
     Undefined = 0,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "RealPowerControlKind_advanced")]
     Advanced = 1,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "RealPowerControlKind_droop")]
     Droop = 2,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "RealPowerControlKind_isochronous")]
     Isochronous = 3,
     /// Real power setpoint
+    #[serde(rename = "RealPowerControlKind_realPower")]
     RealPower = 4,
 }
 /// Real power control kind
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration, serde::Serialize, serde::Deserialize)]
 #[repr(i32)]
-#[derive(serde::Serialize, serde::Deserialize)]
 pub enum ReactivePowerControlKind {
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ReactivePowerControlKind_UNDEFINED")]
     Undefined = 0,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ReactivePowerControlKind_advanced")]
     Advanced = 1,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ReactivePowerControlKind_droop")]
     Droop = 2,
     /// Voltage setpoint
+    #[serde(rename = "ReactivePowerControlKind_voltage")]
     Voltage = 3,
     /// Reactive power setpoint
+    #[serde(rename = "ReactivePowerControlKind_reactivePower")]
     ReactivePower = 4,
     /// MISSING DOCUMENTATION!!!
+    #[serde(rename = "ReactivePowerControlKind_powerFactor")]
     PowerFactor = 5,
 }

--- a/openfmb-messages/src/interconnectionmodule.rs
+++ b/openfmb-messages/src/interconnectionmodule.rs
@@ -1,34 +1,42 @@
 use crate::commonmodule::*;
 /// Point definition (Point)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct InterconnectionPoint {
     /// Black start enable
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "blackStartEnabled")]
     pub black_start_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Enable frequency set point
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "frequencySetPointEnabled")]
     pub frequency_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Island control
     #[prost(message, optional, tag="3")]
+    #[serde(default)]
     pub island: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Black start enable
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "pctHzDroop")]
     pub pct_hz_droop: ::std::option::Option<f32>,
     /// Black start enable
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "pctVDroop")]
     pub pct_v_droop: ::std::option::Option<f32>,
     /// Ramp rates
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "rampRates")]
     pub ramp_rates: ::std::option::Option<super::commonmodule::RampRate>,
     /// Enable reactive power set point
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "reactivePwrSetPointEnabled")]
     pub reactive_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Enable real power set point
     #[prost(message, optional, tag="8")]
+    #[serde(default, rename = "realPwrSetPointEnabled")]
     pub real_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Enable voltage set point
     #[prost(message, optional, tag="9")]
+    #[serde(default, rename = "voltageSetPointEnabled")]
     pub voltage_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Start time
     // parent_message: false
@@ -38,6 +46,7 @@ pub struct InterconnectionPoint {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="10")]
+    #[serde(default, rename = "startTime")]
     pub start_time: ::std::option::Option<super::commonmodule::Timestamp>,
 }
 mod interconnection_point {
@@ -130,8 +139,7 @@ impl IsInterconnectionPoint for InterconnectionPoint {
     }
 }
 /// Curve shape setting (FC=SP) (CSG_SP)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct InterconnectionCsg {
     /// The array with the points specifying a curve shape.
     // parent_message: false
@@ -141,6 +149,7 @@ pub struct InterconnectionCsg {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="1")]
+    #[serde(default, rename = "crvPts")]
     pub crv_pts: ::std::vec::Vec<InterconnectionPoint>,
 }
 mod interconnection_csg {
@@ -169,8 +178,7 @@ impl IsInterconnectionCsg for InterconnectionCsg {
     }
 }
 /// OpenFMB specialization for control schedule using:  LN: Schedule   Name: FSCH
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct InterconnectionControlScheduleFsch {
     /// Discrete value in InterconnectionCSG type
     // parent_message: false
@@ -180,6 +188,7 @@ pub struct InterconnectionControlScheduleFsch {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "ValDCSG")]
     pub val_dcsg: ::std::option::Option<InterconnectionCsg>,
 }
 mod interconnection_control_schedule_fsch {
@@ -209,8 +218,7 @@ impl IsInterconnectionControlScheduleFsch for InterconnectionControlScheduleFsch
     }
 }
 /// Specialized 61850 FSCC class for interconnection schedule
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct InterconnectionScheduleFscc {
     /// UML inherited base object
     // parent_message: true
@@ -220,6 +228,7 @@ pub struct InterconnectionScheduleFscc {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlFSCC")]
     pub control_fscc: ::std::option::Option<super::commonmodule::ControlFscc>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -229,6 +238,7 @@ pub struct InterconnectionScheduleFscc {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="2")]
+    #[serde(default, rename = "interconnectionControlScheduleFSCH")]
     pub interconnection_control_schedule_fsch: ::std::vec::Vec<InterconnectionControlScheduleFsch>,
 }
 mod interconnection_schedule_fscc {
@@ -302,8 +312,7 @@ impl IsIdentifiedObject for InterconnectionScheduleFscc {
     }
 }
 /// Interconnection schedule
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct InterconnectionSchedule {
     /// UML inherited base object
     // parent_message: true
@@ -313,9 +322,11 @@ pub struct InterconnectionSchedule {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<super::commonmodule::IdentifiedObject>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub check: ::std::option::Option<super::commonmodule::CheckConditions>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -325,6 +336,7 @@ pub struct InterconnectionSchedule {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "interconnectionScheduleFSCC")]
     pub interconnection_schedule_fscc: ::std::option::Option<InterconnectionScheduleFscc>,
 }
 mod interconnection_schedule {
@@ -383,8 +395,7 @@ impl IsIdentifiedObject for InterconnectionSchedule {
 }
 /// Planned interconnection schedule profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct PlannedInterconnectionScheduleProfile {
     /// UML inherited base object
     // parent_message: true
@@ -394,6 +405,7 @@ pub struct PlannedInterconnectionScheduleProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -403,6 +415,7 @@ pub struct PlannedInterconnectionScheduleProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "requesterCircuitSegmentService")]
     pub requester_circuit_segment_service: ::std::option::Option<super::commonmodule::ApplicationSystem>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -412,6 +425,7 @@ pub struct PlannedInterconnectionScheduleProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "interconnectionSchedule")]
     pub interconnection_schedule: ::std::option::Option<InterconnectionSchedule>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -421,6 +435,7 @@ pub struct PlannedInterconnectionScheduleProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "tiePoint")]
     pub tie_point: ::std::option::Option<super::commonmodule::ConductingEquipment>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -430,6 +445,7 @@ pub struct PlannedInterconnectionScheduleProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "responderCircuitSegmentService")]
     pub responder_circuit_segment_service: ::std::option::Option<super::commonmodule::ApplicationSystem>,
 }
 mod planned_interconnection_schedule_profile {
@@ -518,8 +534,7 @@ impl IsIdentifiedObject for PlannedInterconnectionScheduleProfile {
 }
 /// Requested interconnection schedule profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RequestedInterconnectionScheduleProfile {
     /// UML inherited base object
     // parent_message: true
@@ -529,6 +544,7 @@ pub struct RequestedInterconnectionScheduleProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -538,6 +554,7 @@ pub struct RequestedInterconnectionScheduleProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "requesterCircuitSegmentService")]
     pub requester_circuit_segment_service: ::std::option::Option<super::commonmodule::ApplicationSystem>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -547,6 +564,7 @@ pub struct RequestedInterconnectionScheduleProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "interconnectionSchedule")]
     pub interconnection_schedule: ::std::option::Option<InterconnectionSchedule>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -556,6 +574,7 @@ pub struct RequestedInterconnectionScheduleProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "tiePoint")]
     pub tie_point: ::std::option::Option<super::commonmodule::ConductingEquipment>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -565,6 +584,7 @@ pub struct RequestedInterconnectionScheduleProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "responderCircuitSegmentService")]
     pub responder_circuit_segment_service: ::std::option::Option<super::commonmodule::ApplicationSystem>,
 }
 mod requested_interconnection_schedule_profile {

--- a/openfmb-messages/src/loadmodule.rs
+++ b/openfmb-messages/src/loadmodule.rs
@@ -1,22 +1,26 @@
 use crate::commonmodule::*;
 /// Point definition (Point)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadPoint {
     /// Ramp rates
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "rampRates")]
     pub ramp_rates: ::std::option::Option<super::commonmodule::RampRate>,
     /// Enable reactive power set point
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "reactivePwrSetPointEnabled")]
     pub reactive_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Enable joint real power set point
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "realPwrSetPointEnabled")]
     pub real_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Reset device
     #[prost(message, optional, tag="4")]
+    #[serde(default)]
     pub reset: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// ESS state
     #[prost(message, optional, tag="5")]
+    #[serde(default)]
     pub state: ::std::option::Option<super::commonmodule::OptionalStateKind>,
     /// Start time
     // parent_message: false
@@ -26,6 +30,7 @@ pub struct LoadPoint {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "startTime")]
     pub start_time: ::std::option::Option<super::commonmodule::ControlTimestamp>,
 }
 mod load_point {
@@ -90,8 +95,7 @@ impl IsLoadPoint for LoadPoint {
     }
 }
 /// Curve shape setting (FC=SP) (CSG_SP)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadCsg {
     /// The array with the points specifying a curve shape.
     // parent_message: false
@@ -101,6 +105,7 @@ pub struct LoadCsg {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="1")]
+    #[serde(default, rename = "crvPts")]
     pub crv_pts: ::std::vec::Vec<LoadPoint>,
 }
 mod load_csg {
@@ -129,8 +134,7 @@ impl IsLoadCsg for LoadCsg {
     }
 }
 /// OpenFMB specialization for control schedule using:  LN: Schedule   Name: FSCH
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadControlScheduleFsch {
     /// Discrete value in LoadCSG type
     // parent_message: false
@@ -140,6 +144,7 @@ pub struct LoadControlScheduleFsch {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "ValDCSG")]
     pub val_dcsg: ::std::option::Option<LoadCsg>,
 }
 mod load_control_schedule_fsch {
@@ -169,8 +174,7 @@ impl IsLoadControlScheduleFsch for LoadControlScheduleFsch {
     }
 }
 /// Specialized FSCC 61850 class.  LN: Schedule controller   Name: FSCC
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadControlFscc {
     /// UML inherited base object
     // parent_message: true
@@ -180,9 +184,11 @@ pub struct LoadControlFscc {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlFSCC")]
     pub control_fscc: ::std::option::Option<super::commonmodule::ControlFscc>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "loadControlScheduleFSCH")]
     pub load_control_schedule_fsch: ::std::option::Option<LoadControlScheduleFsch>,
 }
 mod load_control_fscc {
@@ -257,8 +263,7 @@ impl IsIdentifiedObject for LoadControlFscc {
     }
 }
 /// Load control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadControl {
     /// UML inherited base object
     // parent_message: true
@@ -268,12 +273,15 @@ pub struct LoadControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlValue")]
     pub control_value: ::std::option::Option<super::commonmodule::ControlValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub check: ::std::option::Option<super::commonmodule::CheckConditions>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "loadControlFSCC")]
     pub load_control_fscc: ::std::option::Option<LoadControlFscc>,
 }
 mod load_control {
@@ -340,8 +348,7 @@ impl IsIdentifiedObject for LoadControl {
 }
 /// Load control profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadControlProfile {
     /// UML inherited base object
     // parent_message: true
@@ -351,6 +358,7 @@ pub struct LoadControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -360,6 +368,7 @@ pub struct LoadControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "energyConsumer")]
     pub energy_consumer: ::std::option::Option<super::commonmodule::EnergyConsumer>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -369,6 +378,7 @@ pub struct LoadControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "loadControl")]
     pub load_control: ::std::option::Option<LoadControl>,
 }
 mod load_control_profile {
@@ -442,23 +452,27 @@ impl IsIdentifiedObject for LoadControlProfile {
     }
 }
 /// Point definition (Point)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadPointStatus {
     /// Ramp rates
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "rampRates")]
     pub ramp_rates: ::std::option::Option<super::commonmodule::RampRate>,
     /// Enable reactive power set point
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "reactivePwrSetPointEnabled")]
     pub reactive_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
     /// Enable joint real power set point
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "realPwrSetPointEnabled")]
     pub real_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
     /// Reset device
     #[prost(message, optional, tag="4")]
+    #[serde(default)]
     pub reset: ::std::option::Option<super::commonmodule::StatusDps>,
     /// ESS state
     #[prost(message, optional, tag="5")]
+    #[serde(default)]
     pub state: ::std::option::Option<super::commonmodule::OptionalStateKind>,
 }
 mod load_point_status {
@@ -516,8 +530,7 @@ impl IsLoadPointStatus for LoadPointStatus {
     }
 }
 /// Specialized 61850 ZGLD class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadEventAndStatusZgld {
     /// UML inherited base object
     // parent_message: true
@@ -527,15 +540,19 @@ pub struct LoadEventAndStatusZgld {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForEventAndStatus")]
     pub logical_node_for_event_and_status: ::std::option::Option<super::commonmodule::LogicalNodeForEventAndStatus>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "DynamicTest")]
     pub dynamic_test: ::std::option::Option<super::commonmodule::EnsDynamicTestKind>,
     /// Emergency stop
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "EmgStop")]
     pub emg_stop: ::std::option::Option<super::commonmodule::StatusSps>,
     /// Point status
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "PointStatus")]
     pub point_status: ::std::option::Option<LoadPointStatus>,
 }
 mod load_event_and_status_zgld {
@@ -616,8 +633,7 @@ impl IsIdentifiedObject for LoadEventAndStatusZgld {
     }
 }
 /// Specialized 61850 ZGLD LN class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadEventZgld {
     /// UML inherited base object
     // parent_message: true
@@ -627,6 +643,7 @@ pub struct LoadEventZgld {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "loadEventAndStatusZGLD")]
     pub load_event_and_status_zgld: ::std::option::Option<LoadEventAndStatusZgld>,
 }
 mod load_event_zgld {
@@ -694,8 +711,7 @@ impl IsIdentifiedObject for LoadEventZgld {
     }
 }
 /// Load event
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadEvent {
     /// UML inherited base object
     // parent_message: true
@@ -705,9 +721,11 @@ pub struct LoadEvent {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventValue")]
     pub event_value: ::std::option::Option<super::commonmodule::EventValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "loadEventZGLD")]
     pub load_event_zgld: ::std::option::Option<LoadEventZgld>,
 }
 mod load_event {
@@ -767,8 +785,7 @@ impl IsIdentifiedObject for LoadEvent {
 }
 /// Load event profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadEventProfile {
     /// UML inherited base object
     // parent_message: true
@@ -778,6 +795,7 @@ pub struct LoadEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventMessageInfo")]
     pub event_message_info: ::std::option::Option<super::commonmodule::EventMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -787,6 +805,7 @@ pub struct LoadEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "energyConsumer")]
     pub energy_consumer: ::std::option::Option<super::commonmodule::EnergyConsumer>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -796,6 +815,7 @@ pub struct LoadEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "loadEvent")]
     pub load_event: ::std::option::Option<LoadEvent>,
 }
 mod load_event_profile {
@@ -869,8 +889,7 @@ impl IsIdentifiedObject for LoadEventProfile {
     }
 }
 /// Load reading value
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadReading {
     /// UML inherited base object
     // parent_message: true
@@ -880,15 +899,19 @@ pub struct LoadReading {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipmentTerminalReading")]
     pub conducting_equipment_terminal_reading: ::std::option::Option<super::commonmodule::ConductingEquipmentTerminalReading>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phaseMMTN")]
     pub phase_mmtn: ::std::option::Option<super::commonmodule::PhaseMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "readingMMTR")]
     pub reading_mmtr: ::std::option::Option<super::commonmodule::ReadingMmtr>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "readingMMXU")]
     pub reading_mmxu: ::std::option::Option<super::commonmodule::ReadingMmxu>,
 }
 mod load_reading {
@@ -954,8 +977,7 @@ impl IsConductingEquipmentTerminalReading for LoadReading {
 }
 /// Load reading profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadReadingProfile {
     /// UML inherited base object
     // parent_message: true
@@ -965,6 +987,7 @@ pub struct LoadReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "readingMessageInfo")]
     pub reading_message_info: ::std::option::Option<super::commonmodule::ReadingMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -974,6 +997,7 @@ pub struct LoadReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "energyConsumer")]
     pub energy_consumer: ::std::option::Option<super::commonmodule::EnergyConsumer>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -983,6 +1007,7 @@ pub struct LoadReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "loadReading")]
     pub load_reading: ::std::option::Option<LoadReading>,
 }
 mod load_reading_profile {
@@ -1056,8 +1081,7 @@ impl IsIdentifiedObject for LoadReadingProfile {
     }
 }
 /// Specialized 61850 ZGLD LN class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadStatusZgld {
     /// UML inherited base object
     // parent_message: true
@@ -1067,6 +1091,7 @@ pub struct LoadStatusZgld {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "loadEventAndStatusZGLD")]
     pub load_event_and_status_zgld: ::std::option::Option<LoadEventAndStatusZgld>,
 }
 mod load_status_zgld {
@@ -1134,8 +1159,7 @@ impl IsIdentifiedObject for LoadStatusZgld {
     }
 }
 /// Load status
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadStatus {
     /// UML inherited base object
     // parent_message: true
@@ -1145,12 +1169,15 @@ pub struct LoadStatus {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusValue")]
     pub status_value: ::std::option::Option<super::commonmodule::StatusValue>,
     /// True if the load is uncontrollable.
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "isUncontrollable")]
     pub is_uncontrollable: ::std::option::Option<bool>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "loadStatusZGLD")]
     pub load_status_zgld: ::std::option::Option<LoadStatusZgld>,
 }
 mod load_status {
@@ -1217,8 +1244,7 @@ impl IsIdentifiedObject for LoadStatus {
 }
 /// Load status profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct LoadStatusProfile {
     /// UML inherited base object
     // parent_message: true
@@ -1228,6 +1254,7 @@ pub struct LoadStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusMessageInfo")]
     pub status_message_info: ::std::option::Option<super::commonmodule::StatusMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1237,6 +1264,7 @@ pub struct LoadStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "energyConsumer")]
     pub energy_consumer: ::std::option::Option<super::commonmodule::EnergyConsumer>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1246,6 +1274,7 @@ pub struct LoadStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "loadStatus")]
     pub load_status: ::std::option::Option<LoadStatus>,
 }
 mod load_status_profile {

--- a/openfmb-messages/src/metermodule.rs
+++ b/openfmb-messages/src/metermodule.rs
@@ -1,7 +1,6 @@
 use crate::commonmodule::*;
 /// Resource reading value
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct MeterReading {
     /// UML inherited base object
     // parent_message: true
@@ -11,15 +10,19 @@ pub struct MeterReading {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipmentTerminalReading")]
     pub conducting_equipment_terminal_reading: ::std::option::Option<super::commonmodule::ConductingEquipmentTerminalReading>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phaseMMTN")]
     pub phase_mmtn: ::std::option::Option<super::commonmodule::PhaseMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "readingMMTR")]
     pub reading_mmtr: ::std::option::Option<super::commonmodule::ReadingMmtr>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "readingMMXU")]
     pub reading_mmxu: ::std::option::Option<super::commonmodule::ReadingMmxu>,
 }
 mod meter_reading {
@@ -85,8 +88,7 @@ impl IsConductingEquipmentTerminalReading for MeterReading {
 }
 /// Resource reading profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct MeterReadingProfile {
     /// UML inherited base object
     // parent_message: true
@@ -96,6 +98,7 @@ pub struct MeterReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "readingMessageInfo")]
     pub reading_message_info: ::std::option::Option<super::commonmodule::ReadingMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -105,6 +108,7 @@ pub struct MeterReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub meter: ::std::option::Option<super::commonmodule::Meter>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -114,6 +118,7 @@ pub struct MeterReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "meterReading")]
     pub meter_reading: ::std::option::Option<MeterReading>,
 }
 mod meter_reading_profile {

--- a/openfmb-messages/src/reclosermodule.rs
+++ b/openfmb-messages/src/reclosermodule.rs
@@ -1,8 +1,7 @@
 use crate::commonmodule::*;
 /// Protection mode such as a group setting or pre-defined curve profile. It is usually pre-defined
 /// by a circuit segment service.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RecloserDiscreteControlXcbr {
     /// UML inherited base object
     // parent_message: true
@@ -12,6 +11,7 @@ pub struct RecloserDiscreteControlXcbr {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "discreteControlXCBR")]
     pub discrete_control_xcbr: ::std::option::Option<super::commonmodule::DiscreteControlXcbr>,
 }
 mod recloser_discrete_control_xcbr {
@@ -79,8 +79,7 @@ impl IsIdentifiedObject for RecloserDiscreteControlXcbr {
     }
 }
 /// Recloser discrete control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RecloserDiscreteControl {
     /// UML inherited base object
     // parent_message: true
@@ -90,12 +89,15 @@ pub struct RecloserDiscreteControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlValue")]
     pub control_value: ::std::option::Option<super::commonmodule::ControlValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub check: ::std::option::Option<super::commonmodule::CheckConditions>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "recloserDiscreteControlXCBR")]
     pub recloser_discrete_control_xcbr: ::std::option::Option<RecloserDiscreteControlXcbr>,
 }
 mod recloser_discrete_control {
@@ -162,8 +164,7 @@ impl IsIdentifiedObject for RecloserDiscreteControl {
 }
 /// Pole-mounted fault interrupter with built-in phase and ground relays, current transformer (CT),
 /// and supplemental controls.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct Recloser {
     /// UML inherited base object
     // parent_message: true
@@ -173,9 +174,11 @@ pub struct Recloser {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipment")]
     pub conducting_equipment: ::std::option::Option<super::commonmodule::ConductingEquipment>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "normalOpen")]
     pub normal_open: ::std::option::Option<bool>,
 }
 mod recloser {
@@ -236,8 +239,7 @@ impl IsNamedObject for Recloser {
 /// Recloser control profile.  Instructs an end device (or an end device group) to perform a
 /// specified action.
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RecloserDiscreteControlProfile {
     /// UML inherited base object
     // parent_message: true
@@ -247,6 +249,7 @@ pub struct RecloserDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -256,6 +259,7 @@ pub struct RecloserDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub recloser: ::std::option::Option<Recloser>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -265,6 +269,7 @@ pub struct RecloserDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "recloserDiscreteControl")]
     pub recloser_discrete_control: ::std::option::Option<RecloserDiscreteControl>,
 }
 mod recloser_discrete_control_profile {
@@ -338,8 +343,7 @@ impl IsIdentifiedObject for RecloserDiscreteControlProfile {
     }
 }
 /// Recloser event
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RecloserEvent {
     /// UML inherited base object
     // parent_message: true
@@ -349,9 +353,11 @@ pub struct RecloserEvent {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventValue")]
     pub event_value: ::std::option::Option<super::commonmodule::EventValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "statusAndEventXCBR")]
     pub status_and_event_xcbr: ::std::option::Option<super::commonmodule::StatusAndEventXcbr>,
 }
 mod recloser_event {
@@ -411,8 +417,7 @@ impl IsIdentifiedObject for RecloserEvent {
 }
 /// Recloser event profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RecloserEventProfile {
     /// UML inherited base object
     // parent_message: true
@@ -422,6 +427,7 @@ pub struct RecloserEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventMessageInfo")]
     pub event_message_info: ::std::option::Option<super::commonmodule::EventMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -431,6 +437,7 @@ pub struct RecloserEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub recloser: ::std::option::Option<Recloser>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -440,6 +447,7 @@ pub struct RecloserEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "recloserEvent")]
     pub recloser_event: ::std::option::Option<RecloserEvent>,
 }
 mod recloser_event_profile {
@@ -513,8 +521,7 @@ impl IsIdentifiedObject for RecloserEventProfile {
     }
 }
 /// Recloser reading value
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RecloserReading {
     /// UML inherited base object
     // parent_message: true
@@ -524,18 +531,23 @@ pub struct RecloserReading {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipmentTerminalReading")]
     pub conducting_equipment_terminal_reading: ::std::option::Option<super::commonmodule::ConductingEquipmentTerminalReading>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "diffReadingMMXU")]
     pub diff_reading_mmxu: ::std::option::Option<super::commonmodule::ReadingMmxu>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "phaseMMTN")]
     pub phase_mmtn: ::std::option::Option<super::commonmodule::PhaseMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "readingMMTR")]
     pub reading_mmtr: ::std::option::Option<super::commonmodule::ReadingMmtr>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "readingMMXU")]
     pub reading_mmxu: ::std::option::Option<super::commonmodule::ReadingMmxu>,
 }
 mod recloser_reading {
@@ -608,8 +620,7 @@ impl IsConductingEquipmentTerminalReading for RecloserReading {
 }
 /// Recloser reading profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RecloserReadingProfile {
     /// UML inherited base object
     // parent_message: true
@@ -619,6 +630,7 @@ pub struct RecloserReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "readingMessageInfo")]
     pub reading_message_info: ::std::option::Option<super::commonmodule::ReadingMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -628,6 +640,7 @@ pub struct RecloserReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub recloser: ::std::option::Option<Recloser>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -637,6 +650,7 @@ pub struct RecloserReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="3")]
+    #[serde(default, rename = "recloserReading")]
     pub recloser_reading: ::std::vec::Vec<RecloserReading>,
 }
 mod recloser_reading_profile {
@@ -709,8 +723,7 @@ impl IsIdentifiedObject for RecloserReadingProfile {
     }
 }
 /// Recloser status
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RecloserStatus {
     /// UML inherited base object
     // parent_message: true
@@ -720,9 +733,11 @@ pub struct RecloserStatus {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusValue")]
     pub status_value: ::std::option::Option<super::commonmodule::StatusValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "statusAndEventXCBR")]
     pub status_and_event_xcbr: ::std::option::Option<super::commonmodule::StatusAndEventXcbr>,
 }
 mod recloser_status {
@@ -782,8 +797,7 @@ impl IsIdentifiedObject for RecloserStatus {
 }
 /// Recloser status profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RecloserStatusProfile {
     /// UML inherited base object
     // parent_message: true
@@ -793,6 +807,7 @@ pub struct RecloserStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusMessageInfo")]
     pub status_message_info: ::std::option::Option<super::commonmodule::StatusMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -802,6 +817,7 @@ pub struct RecloserStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub recloser: ::std::option::Option<Recloser>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -811,6 +827,7 @@ pub struct RecloserStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "recloserStatus")]
     pub recloser_status: ::std::option::Option<RecloserStatus>,
 }
 mod recloser_status_profile {

--- a/openfmb-messages/src/regulatormodule.rs
+++ b/openfmb-messages/src/regulatormodule.rs
@@ -1,7 +1,6 @@
 use crate::commonmodule::*;
 /// LN: Automatic tap changer controller   Name: ATCC
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorControlAtcc {
     /// UML inherited base object
     // parent_message: true
@@ -11,40 +10,52 @@ pub struct RegulatorControlAtcc {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForControl")]
     pub logical_node_for_control: ::std::option::Option<super::commonmodule::LogicalNodeForControl>,
     /// Centre of voltage control bandwidth (forward power flow presumed).
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "BndCtr")]
     pub bnd_ctr: ::std::option::Option<super::commonmodule::Asg>,
     /// Control (secondary) voltage bandwidth (i.e., range), given either as voltage value or percentage
     /// of the nominal voltage (forward power flow presumed).
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "BndWid")]
     pub bnd_wid: ::std::option::Option<super::commonmodule::Asg>,
     /// Time to wait before operating, after reaching the control point (forward power flow presumed).
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "CtlDlTmms")]
     pub ctl_dl_tmms: ::std::option::Option<super::commonmodule::ControlIng>,
     /// Line drop voltage due to line resistance component (forward power flow presumed) at rated current.
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "LDCR")]
     pub ldcr: ::std::option::Option<super::commonmodule::Asg>,
     /// Line drop voltage due to line reactance component (forward power flow presumed) at rated current.
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "LDCX")]
     pub ldcx: ::std::option::Option<super::commonmodule::Asg>,
     /// (controllable) If true, transformers operate in parallel, otherwise they operate independently.
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "ParOp")]
     pub par_op: ::std::option::Option<super::commonmodule::ControlSpc>,
     /// Ramp rates
     #[prost(message, optional, tag="8")]
+    #[serde(default, rename = "rampRates")]
     pub ramp_rates: ::std::option::Option<super::commonmodule::RampRate>,
     /// (controllable) Tap position change to the specified value.
     #[prost(message, optional, tag="9")]
+    #[serde(default)]
     pub state: ::std::option::Option<super::commonmodule::OptionalStateKind>,
     /// (controllable) Tap position change to the specified value.
     #[prost(message, optional, tag="10")]
+    #[serde(default, rename = "TapPos")]
     pub tap_pos: ::std::option::Option<super::commonmodule::PhaseIsc>,
     /// (controllable) Voltage setpoint. Analog value (MX) feeds back the setpoint of the controller.
     #[prost(message, optional, tag="11")]
+    #[serde(default, rename = "VolSpt")]
     pub vol_spt: ::std::option::Option<super::commonmodule::PhaseApc>,
     /// Enable voltage set point
     #[prost(message, optional, tag="12")]
+    #[serde(default, rename = "voltageSetPointEnabled")]
     pub voltage_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
 }
 mod regulator_control_atcc {
@@ -181,11 +192,11 @@ impl IsIdentifiedObject for RegulatorControlAtcc {
     }
 }
 /// Point definition (Point)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorPoint {
     /// Regulator control
     #[prost(message, optional, tag="1")]
+    #[serde(default)]
     pub control: ::std::option::Option<RegulatorControlAtcc>,
     /// Start time
     // parent_message: false
@@ -195,6 +206,7 @@ pub struct RegulatorPoint {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="8")]
+    #[serde(default, rename = "startTime")]
     pub start_time: ::std::option::Option<super::commonmodule::Timestamp>,
 }
 mod regulator_point {
@@ -231,8 +243,7 @@ impl IsRegulatorPoint for RegulatorPoint {
     }
 }
 /// Curve shape setting (FC=SP) (CSG_SP)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorCsg {
     /// The array with the points specifying a curve shape.
     // parent_message: false
@@ -242,6 +253,7 @@ pub struct RegulatorCsg {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="1")]
+    #[serde(default, rename = "crvPts")]
     pub crv_pts: ::std::vec::Vec<RegulatorPoint>,
 }
 mod regulator_csg {
@@ -270,8 +282,7 @@ impl IsRegulatorCsg for RegulatorCsg {
     }
 }
 /// OpenFMB specialization for control schedule using:  LN: Schedule   Name: FSCH
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorControlScheduleFsch {
     /// Discrete value in RegulatorCSG type
     // parent_message: false
@@ -281,6 +292,7 @@ pub struct RegulatorControlScheduleFsch {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "ValDCSG")]
     pub val_dcsg: ::std::option::Option<RegulatorCsg>,
 }
 mod regulator_control_schedule_fsch {
@@ -310,8 +322,7 @@ impl IsRegulatorControlScheduleFsch for RegulatorControlScheduleFsch {
     }
 }
 /// Using 61850 FSCC for regulator control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorControlFscc {
     /// UML inherited base object
     // parent_message: true
@@ -321,9 +332,11 @@ pub struct RegulatorControlFscc {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlFSCC")]
     pub control_fscc: ::std::option::Option<super::commonmodule::ControlFscc>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "regulatorControlScheduleFSCH")]
     pub regulator_control_schedule_fsch: ::std::option::Option<RegulatorControlScheduleFsch>,
 }
 mod regulator_control_fscc {
@@ -398,8 +411,7 @@ impl IsIdentifiedObject for RegulatorControlFscc {
     }
 }
 /// Regulator control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorControl {
     /// UML inherited base object
     // parent_message: true
@@ -409,12 +421,15 @@ pub struct RegulatorControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlValue")]
     pub control_value: ::std::option::Option<super::commonmodule::ControlValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub check: ::std::option::Option<super::commonmodule::CheckConditions>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "regulatorControlFSCC")]
     pub regulator_control_fscc: ::std::option::Option<RegulatorControlFscc>,
 }
 mod regulator_control {
@@ -481,8 +496,7 @@ impl IsIdentifiedObject for RegulatorControl {
 }
 /// Pole-mounted fault interrupter with built-in phase and ground relays, current transformer (CT),
 /// and supplemental controls.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorSystem {
     /// UML inherited base object
     // parent_message: true
@@ -492,6 +506,7 @@ pub struct RegulatorSystem {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipment")]
     pub conducting_equipment: ::std::option::Option<super::commonmodule::ConductingEquipment>,
 }
 mod regulator_system {
@@ -545,8 +560,7 @@ impl IsNamedObject for RegulatorSystem {
 /// Regulator control profile.  Instructs an end device (or an end device group) to perform a
 /// specified action.
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorControlProfile {
     /// UML inherited base object
     // parent_message: true
@@ -556,6 +570,7 @@ pub struct RegulatorControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -565,6 +580,7 @@ pub struct RegulatorControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "regulatorControl")]
     pub regulator_control: ::std::option::Option<RegulatorControl>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -574,6 +590,7 @@ pub struct RegulatorControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "regulatorSystem")]
     pub regulator_system: ::std::option::Option<RegulatorSystem>,
 }
 mod regulator_control_profile {
@@ -647,8 +664,7 @@ impl IsIdentifiedObject for RegulatorControlProfile {
     }
 }
 /// Regulator control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorDiscreteControl {
     /// UML inherited base object
     // parent_message: true
@@ -658,12 +674,15 @@ pub struct RegulatorDiscreteControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlValue")]
     pub control_value: ::std::option::Option<super::commonmodule::ControlValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub check: ::std::option::Option<super::commonmodule::CheckConditions>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "regulatorControlATCC")]
     pub regulator_control_atcc: ::std::option::Option<RegulatorControlAtcc>,
 }
 mod regulator_discrete_control {
@@ -731,8 +750,7 @@ impl IsIdentifiedObject for RegulatorDiscreteControl {
 /// Regulator control profile.  Instructs an end device (or an end device group) to perform a
 /// specified action.
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorDiscreteControlProfile {
     /// UML inherited base object
     // parent_message: true
@@ -742,6 +760,7 @@ pub struct RegulatorDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -751,6 +770,7 @@ pub struct RegulatorDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "regulatorDiscreteControl")]
     pub regulator_discrete_control: ::std::option::Option<RegulatorDiscreteControl>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -760,6 +780,7 @@ pub struct RegulatorDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "regulatorSystem")]
     pub regulator_system: ::std::option::Option<RegulatorSystem>,
 }
 mod regulator_discrete_control_profile {
@@ -833,46 +854,57 @@ impl IsIdentifiedObject for RegulatorDiscreteControlProfile {
     }
 }
 /// LN: Automatic tap changer controller   Name: ATCC
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorEventAndStatusAtcc {
     /// Centre of voltage control bandwidth (forward power flow presumed).
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "BndCtr")]
     pub bnd_ctr: ::std::option::Option<super::commonmodule::Asg>,
     /// Control (secondary) voltage bandwidth (i.e., range), given either as voltage value or percentage
     /// of the nominal voltage (forward power flow presumed).
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "BndWid")]
     pub bnd_wid: ::std::option::Option<super::commonmodule::Asg>,
     /// Line drop voltage due to line resistance component (forward power flow presumed) at rated current.
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "LDCR")]
     pub ldcr: ::std::option::Option<super::commonmodule::Asg>,
     /// Line drop voltage due to line reactance component (forward power flow presumed) at rated current.
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "LDCX")]
     pub ldcx: ::std::option::Option<super::commonmodule::Asg>,
     /// (controllable) If true, transformers operate in parallel, otherwise they operate independently.
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "ParOp")]
     pub par_op: ::std::option::Option<super::commonmodule::StatusSps>,
     /// Ramp rates
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "rampRates")]
     pub ramp_rates: ::std::option::Option<super::commonmodule::RampRate>,
     /// State
     #[prost(message, optional, tag="7")]
+    #[serde(default)]
     pub state: ::std::option::Option<super::commonmodule::OptionalStateKind>,
     /// OpenFMB extension:  Status for the time to wait before operating (CtrlDlTmms)
     #[prost(message, optional, tag="8")]
+    #[serde(default, rename = "StDlTmms")]
     pub st_dl_tmms: ::std::option::Option<super::commonmodule::StatusInc>,
     /// If true, there was an error in tap position change, or in tap indication (for instance, wrong
     /// Binary Coded Decimal (BCD) code).
     #[prost(message, optional, tag="9")]
+    #[serde(default, rename = "TapOpErr")]
     pub tap_op_err: ::std::option::Option<super::commonmodule::StatusSps>,
     /// (controllable) Tap position change to the specified value.
     #[prost(message, optional, tag="10")]
+    #[serde(default, rename = "TapPos")]
     pub tap_pos: ::std::option::Option<super::commonmodule::PhaseIns>,
     /// (controllable) Voltage setpoint. Analog value (MX) feeds back the setpoint of the controller.
     #[prost(message, optional, tag="11")]
+    #[serde(default, rename = "VolSpt")]
     pub vol_spt: ::std::option::Option<super::commonmodule::PhaseApc>,
     /// Voltage set point status
     #[prost(message, optional, tag="12")]
+    #[serde(default, rename = "voltageSetPointEnabled")]
     pub voltage_set_point_enabled: ::std::option::Option<super::commonmodule::StatusSpc>,
 }
 mod regulator_event_and_status_atcc {
@@ -979,8 +1011,7 @@ impl IsRegulatorEventAndStatusAtcc for RegulatorEventAndStatusAtcc {
     }
 }
 /// OpenFMB 61850 specialization for both RegulatorEventProfile and RegulatorStatusProfile
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorEventAndStatusAncr {
     /// UML inherited base object
     // parent_message: true
@@ -990,12 +1021,15 @@ pub struct RegulatorEventAndStatusAncr {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForEventAndStatus")]
     pub logical_node_for_event_and_status: ::std::option::Option<super::commonmodule::LogicalNodeForEventAndStatus>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "DynamicTest")]
     pub dynamic_test: ::std::option::Option<super::commonmodule::EnsDynamicTestKind>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "PointStatus")]
     pub point_status: ::std::option::Option<RegulatorEventAndStatusAtcc>,
 }
 mod regulator_event_and_status_ancr {
@@ -1069,8 +1103,7 @@ impl IsIdentifiedObject for RegulatorEventAndStatusAncr {
     }
 }
 /// Regulator event
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorEvent {
     /// UML inherited base object
     // parent_message: true
@@ -1080,9 +1113,11 @@ pub struct RegulatorEvent {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventValue")]
     pub event_value: ::std::option::Option<super::commonmodule::EventValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "regulatorEventAndStatusANCR")]
     pub regulator_event_and_status_ancr: ::std::option::Option<RegulatorEventAndStatusAncr>,
 }
 mod regulator_event {
@@ -1142,8 +1177,7 @@ impl IsIdentifiedObject for RegulatorEvent {
 }
 /// Regulator event profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorEventProfile {
     /// UML inherited base object
     // parent_message: true
@@ -1153,6 +1187,7 @@ pub struct RegulatorEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventMessageInfo")]
     pub event_message_info: ::std::option::Option<super::commonmodule::EventMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1162,6 +1197,7 @@ pub struct RegulatorEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "regulatorEvent")]
     pub regulator_event: ::std::option::Option<RegulatorEvent>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1171,6 +1207,7 @@ pub struct RegulatorEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "regulatorSystem")]
     pub regulator_system: ::std::option::Option<RegulatorSystem>,
 }
 mod regulator_event_profile {
@@ -1244,8 +1281,7 @@ impl IsIdentifiedObject for RegulatorEventProfile {
     }
 }
 /// Regulator reading value
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorReading {
     /// UML inherited base object
     // parent_message: true
@@ -1255,15 +1291,19 @@ pub struct RegulatorReading {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipmentTerminalReading")]
     pub conducting_equipment_terminal_reading: ::std::option::Option<super::commonmodule::ConductingEquipmentTerminalReading>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phaseMMTN")]
     pub phase_mmtn: ::std::option::Option<super::commonmodule::PhaseMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "readingMMTR")]
     pub reading_mmtr: ::std::option::Option<super::commonmodule::ReadingMmtr>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "readingMMXU")]
     pub reading_mmxu: ::std::option::Option<super::commonmodule::ReadingMmxu>,
 }
 mod regulator_reading {
@@ -1329,8 +1369,7 @@ impl IsConductingEquipmentTerminalReading for RegulatorReading {
 }
 /// Regulator reading profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorReadingProfile {
     /// UML inherited base object
     // parent_message: true
@@ -1340,6 +1379,7 @@ pub struct RegulatorReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "readingMessageInfo")]
     pub reading_message_info: ::std::option::Option<super::commonmodule::ReadingMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1349,6 +1389,7 @@ pub struct RegulatorReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="2")]
+    #[serde(default, rename = "regulatorReading")]
     pub regulator_reading: ::std::vec::Vec<RegulatorReading>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1358,6 +1399,7 @@ pub struct RegulatorReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "regulatorSystem")]
     pub regulator_system: ::std::option::Option<RegulatorSystem>,
 }
 mod regulator_reading_profile {
@@ -1430,8 +1472,7 @@ impl IsIdentifiedObject for RegulatorReadingProfile {
     }
 }
 /// Regulator status
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorStatus {
     /// UML inherited base object
     // parent_message: true
@@ -1441,9 +1482,11 @@ pub struct RegulatorStatus {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusValue")]
     pub status_value: ::std::option::Option<super::commonmodule::StatusValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "regulatorEventAndStatusANCR")]
     pub regulator_event_and_status_ancr: ::std::option::Option<RegulatorEventAndStatusAncr>,
 }
 mod regulator_status {
@@ -1503,8 +1546,7 @@ impl IsIdentifiedObject for RegulatorStatus {
 }
 /// Regulator status profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct RegulatorStatusProfile {
     /// UML inherited base object
     // parent_message: true
@@ -1514,6 +1556,7 @@ pub struct RegulatorStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusMessageInfo")]
     pub status_message_info: ::std::option::Option<super::commonmodule::StatusMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1523,6 +1566,7 @@ pub struct RegulatorStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "regulatorStatus")]
     pub regulator_status: ::std::option::Option<RegulatorStatus>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1532,6 +1576,7 @@ pub struct RegulatorStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "regulatorSystem")]
     pub regulator_system: ::std::option::Option<RegulatorSystem>,
 }
 mod regulator_status_profile {

--- a/openfmb-messages/src/resourcemodule.rs
+++ b/openfmb-messages/src/resourcemodule.rs
@@ -1,7 +1,6 @@
 use crate::commonmodule::*;
 /// LN: Generic process I/O   Name: GGIO
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct BooleanControlGgio {
     /// UML inherited base object
     // parent_message: true
@@ -11,9 +10,11 @@ pub struct BooleanControlGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNode")]
     pub logical_node: ::std::option::Option<super::commonmodule::LogicalNode>,
     /// Phase code
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "Phase")]
     pub phase: ::std::option::Option<super::commonmodule::OptionalPhaseCodeKind>,
     /// (controllable) If true, generic single point controllable status output <i>n</i> has been
     /// enabled, otherwise it has been disabled.
@@ -24,6 +25,7 @@ pub struct BooleanControlGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "SPCSO")]
     pub spcso: ::std::option::Option<super::commonmodule::ControlSpc>,
 }
 mod boolean_control_ggio {
@@ -89,8 +91,7 @@ impl IsIdentifiedObject for BooleanControlGgio {
     }
 }
 /// Status expressed in integer based on IEC61850 GGIO.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct IntegerControlGgio {
     /// UML inherited base object
     // parent_message: true
@@ -100,6 +101,7 @@ pub struct IntegerControlGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNode")]
     pub logical_node: ::std::option::Option<super::commonmodule::LogicalNode>,
     /// (controllable) Generic integer controllable status output <i>n</i>.
     // parent_message: false
@@ -109,9 +111,11 @@ pub struct IntegerControlGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "ISCSO")]
     pub iscso: ::std::option::Option<super::commonmodule::ControlInc>,
     /// Phase code
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "Phase")]
     pub phase: ::std::option::Option<super::commonmodule::OptionalPhaseCodeKind>,
 }
 mod integer_control_ggio {
@@ -177,8 +181,7 @@ impl IsIdentifiedObject for IntegerControlGgio {
     }
 }
 /// LN: Generic process I/O   Name: GGIO
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct StringControlGgio {
     /// UML inherited base object
     // parent_message: true
@@ -188,9 +191,11 @@ pub struct StringControlGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNode")]
     pub logical_node: ::std::option::Option<super::commonmodule::LogicalNode>,
     /// Phase code
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "Phase")]
     pub phase: ::std::option::Option<super::commonmodule::OptionalPhaseCodeKind>,
     /// String control
     // parent_message: false
@@ -200,6 +205,7 @@ pub struct StringControlGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "StrOut")]
     pub str_out: ::std::option::Option<super::commonmodule::Vsc>,
 }
 mod string_control_ggio {
@@ -265,8 +271,7 @@ impl IsIdentifiedObject for StringControlGgio {
     }
 }
 /// LN: Generic process I/O   Name: GGIO
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct AnalogControlGgio {
     /// UML inherited base object
     // parent_message: true
@@ -276,6 +281,7 @@ pub struct AnalogControlGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNode")]
     pub logical_node: ::std::option::Option<super::commonmodule::LogicalNode>,
     /// (controllable) Value of the generic controllable analogue output setpoint <i>n</i>. Analog value
     /// (MX) feeds back the setpoint of the output.
@@ -286,9 +292,11 @@ pub struct AnalogControlGgio {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "AnOut")]
     pub an_out: ::std::option::Option<super::commonmodule::ControlApc>,
     /// Phase code
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "Phase")]
     pub phase: ::std::option::Option<super::commonmodule::OptionalPhaseCodeKind>,
 }
 mod analog_control_ggio {
@@ -354,8 +362,7 @@ impl IsIdentifiedObject for AnalogControlGgio {
     }
 }
 /// Resource discrete control class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ResourceDiscreteControl {
     /// UML inherited base object
     // parent_message: true
@@ -365,9 +372,11 @@ pub struct ResourceDiscreteControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<super::commonmodule::IdentifiedObject>,
     /// IEC61850 enhanced control parameters.
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub check: ::std::option::Option<super::commonmodule::CheckConditions>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -377,6 +386,7 @@ pub struct ResourceDiscreteControl {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="3")]
+    #[serde(default, rename = "analogControlGGIO")]
     pub analog_control_ggio: ::std::vec::Vec<AnalogControlGgio>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -386,6 +396,7 @@ pub struct ResourceDiscreteControl {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="4")]
+    #[serde(default, rename = "booleanControlGGIO")]
     pub boolean_control_ggio: ::std::vec::Vec<BooleanControlGgio>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -395,6 +406,7 @@ pub struct ResourceDiscreteControl {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="5")]
+    #[serde(default, rename = "integerControlGGIO")]
     pub integer_control_ggio: ::std::vec::Vec<IntegerControlGgio>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -404,6 +416,7 @@ pub struct ResourceDiscreteControl {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="6")]
+    #[serde(default, rename = "stringControlGGIO")]
     pub string_control_ggio: ::std::vec::Vec<StringControlGgio>,
 }
 mod resource_discrete_control {
@@ -479,8 +492,7 @@ impl IsIdentifiedObject for ResourceDiscreteControl {
 }
 /// Instructs a resource to perform a specified action.
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ResourceDiscreteControlProfile {
     /// UML inherited base object
     // parent_message: true
@@ -490,6 +502,7 @@ pub struct ResourceDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -499,6 +512,7 @@ pub struct ResourceDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "conductingEquipment")]
     pub conducting_equipment: ::std::option::Option<super::commonmodule::ConductingEquipment>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -508,6 +522,7 @@ pub struct ResourceDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "resourceDiscreteControl")]
     pub resource_discrete_control: ::std::option::Option<ResourceDiscreteControl>,
 }
 mod resource_discrete_control_profile {
@@ -581,8 +596,7 @@ impl IsIdentifiedObject for ResourceDiscreteControlProfile {
     }
 }
 /// Resource reading value
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ResourceReading {
     /// UML inherited base object
     // parent_message: true
@@ -592,15 +606,19 @@ pub struct ResourceReading {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipmentTerminalReading")]
     pub conducting_equipment_terminal_reading: ::std::option::Option<super::commonmodule::ConductingEquipmentTerminalReading>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phaseMMTN")]
     pub phase_mmtn: ::std::option::Option<super::commonmodule::PhaseMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "readingMMTR")]
     pub reading_mmtr: ::std::option::Option<super::commonmodule::ReadingMmtr>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "readingMMXU")]
     pub reading_mmxu: ::std::option::Option<super::commonmodule::ReadingMmxu>,
 }
 mod resource_reading {
@@ -666,8 +684,7 @@ impl IsConductingEquipmentTerminalReading for ResourceReading {
 }
 /// Resource reading profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ResourceReadingProfile {
     /// UML inherited base object
     // parent_message: true
@@ -677,6 +694,7 @@ pub struct ResourceReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "readingMessageInfo")]
     pub reading_message_info: ::std::option::Option<super::commonmodule::ReadingMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -686,6 +704,7 @@ pub struct ResourceReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "conductingEquipment")]
     pub conducting_equipment: ::std::option::Option<super::commonmodule::ConductingEquipment>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -695,6 +714,7 @@ pub struct ResourceReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "resourceReading")]
     pub resource_reading: ::std::option::Option<ResourceReading>,
 }
 mod resource_reading_profile {
@@ -768,8 +788,7 @@ impl IsIdentifiedObject for ResourceReadingProfile {
     }
 }
 /// Current event information relevant to an entity.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ResourceEvent {
     /// UML inherited base object
     // parent_message: true
@@ -779,6 +798,7 @@ pub struct ResourceEvent {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<super::commonmodule::IdentifiedObject>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -788,6 +808,7 @@ pub struct ResourceEvent {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="2")]
+    #[serde(default, rename = "analogEventAndStatusGGIO")]
     pub analog_event_and_status_ggio: ::std::vec::Vec<super::commonmodule::AnalogEventAndStatusGgio>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -797,6 +818,7 @@ pub struct ResourceEvent {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="3")]
+    #[serde(default, rename = "booleanEventAndStatusGGIO")]
     pub boolean_event_and_status_ggio: ::std::vec::Vec<super::commonmodule::BooleanEventAndStatusGgio>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -806,6 +828,7 @@ pub struct ResourceEvent {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="4")]
+    #[serde(default, rename = "integerEventAndStatusGGIO")]
     pub integer_event_and_status_ggio: ::std::vec::Vec<super::commonmodule::IntegerEventAndStatusGgio>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -815,6 +838,7 @@ pub struct ResourceEvent {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="5")]
+    #[serde(default, rename = "stringEventAndStatusGGIO")]
     pub string_event_and_status_ggio: ::std::vec::Vec<super::commonmodule::StringEventAndStatusGgio>,
 }
 mod resource_event {
@@ -883,8 +907,7 @@ impl IsIdentifiedObject for ResourceEvent {
 }
 /// Resource event module
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ResourceEventProfile {
     /// UML inherited base object
     // parent_message: true
@@ -894,6 +917,7 @@ pub struct ResourceEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventMessageInfo")]
     pub event_message_info: ::std::option::Option<super::commonmodule::EventMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -903,6 +927,7 @@ pub struct ResourceEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "conductingEquipment")]
     pub conducting_equipment: ::std::option::Option<super::commonmodule::ConductingEquipment>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -912,6 +937,7 @@ pub struct ResourceEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "resourceEvent")]
     pub resource_event: ::std::option::Option<ResourceEvent>,
 }
 mod resource_event_profile {
@@ -985,8 +1011,7 @@ impl IsIdentifiedObject for ResourceEventProfile {
     }
 }
 /// Current status information relevant to an entity.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ResourceStatus {
     /// UML inherited base object
     // parent_message: true
@@ -996,6 +1021,7 @@ pub struct ResourceStatus {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "identifiedObject")]
     pub identified_object: ::std::option::Option<super::commonmodule::IdentifiedObject>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1005,6 +1031,7 @@ pub struct ResourceStatus {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="2")]
+    #[serde(default, rename = "analogEventAndStatusGGIO")]
     pub analog_event_and_status_ggio: ::std::vec::Vec<super::commonmodule::AnalogEventAndStatusGgio>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1014,6 +1041,7 @@ pub struct ResourceStatus {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="3")]
+    #[serde(default, rename = "booleanEventAndStatusGGIO")]
     pub boolean_event_and_status_ggio: ::std::vec::Vec<super::commonmodule::BooleanEventAndStatusGgio>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1023,6 +1051,7 @@ pub struct ResourceStatus {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="4")]
+    #[serde(default, rename = "integerEventAndStatusGGIO")]
     pub integer_event_and_status_ggio: ::std::vec::Vec<super::commonmodule::IntegerEventAndStatusGgio>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1032,6 +1061,7 @@ pub struct ResourceStatus {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="5")]
+    #[serde(default, rename = "stringEventAndStatusGGIO")]
     pub string_event_and_status_ggio: ::std::vec::Vec<super::commonmodule::StringEventAndStatusGgio>,
 }
 mod resource_status {
@@ -1100,8 +1130,7 @@ impl IsIdentifiedObject for ResourceStatus {
 }
 /// Resource status module
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ResourceStatusProfile {
     /// UML inherited base object
     // parent_message: true
@@ -1111,6 +1140,7 @@ pub struct ResourceStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusMessageInfo")]
     pub status_message_info: ::std::option::Option<super::commonmodule::StatusMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1120,6 +1150,7 @@ pub struct ResourceStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "conductingEquipment")]
     pub conducting_equipment: ::std::option::Option<super::commonmodule::ConductingEquipment>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1129,6 +1160,7 @@ pub struct ResourceStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "resourceStatus")]
     pub resource_status: ::std::option::Option<ResourceStatus>,
 }
 mod resource_status_profile {

--- a/openfmb-messages/src/solarmodule.rs
+++ b/openfmb-messages/src/solarmodule.rs
@@ -1,37 +1,46 @@
 use crate::commonmodule::*;
 /// Point definition (Point)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarPoint {
     /// Enable frequency set point
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "frequencySetPointEnabled")]
     pub frequency_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Grid connect mode
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub mode: ::std::option::Option<super::commonmodule::EngGridConnectModeKind>,
     /// Black start enable
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "pctHzDroop")]
     pub pct_hz_droop: ::std::option::Option<f32>,
     /// Black start enable
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "pctVDroop")]
     pub pct_v_droop: ::std::option::Option<f32>,
     /// Ramp rates
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "rampRates")]
     pub ramp_rates: ::std::option::Option<super::commonmodule::RampRate>,
     /// Enable reactive power set point
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "reactivePwrSetPointEnabled")]
     pub reactive_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Enable real power set point
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "realPwrSetPointEnabled")]
     pub real_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// Reset device
     #[prost(message, optional, tag="8")]
+    #[serde(default)]
     pub reset: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// ESS state
     #[prost(message, optional, tag="9")]
+    #[serde(default)]
     pub state: ::std::option::Option<super::commonmodule::OptionalStateKind>,
     /// Enable voltage set point
     #[prost(message, optional, tag="10")]
+    #[serde(default, rename = "voltageSetPointEnabled")]
     pub voltage_set_point_enabled: ::std::option::Option<super::commonmodule::ControlDpc>,
     /// X-axis value (Unix time).
     // parent_message: false
@@ -41,6 +50,7 @@ pub struct SolarPoint {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="11")]
+    #[serde(default, rename = "startTime")]
     pub start_time: ::std::option::Option<super::commonmodule::ControlTimestamp>,
 }
 mod solar_point {
@@ -140,8 +150,7 @@ impl IsSolarPoint for SolarPoint {
     }
 }
 /// Curve shape setting (FC=SP) (CSG_SP)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarCsg {
     /// The array with the points specifying a curve shape.
     // parent_message: false
@@ -151,6 +160,7 @@ pub struct SolarCsg {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="1")]
+    #[serde(default, rename = "crvPts")]
     pub crv_pts: ::std::vec::Vec<SolarPoint>,
 }
 mod solar_csg {
@@ -179,8 +189,7 @@ impl IsSolarCsg for SolarCsg {
     }
 }
 /// OpenFMB specialization for control schedule using:  LN: Schedule   Name: FSCH
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarControlScheduleFsch {
     /// Discrete value in SolarCSG type
     // parent_message: false
@@ -190,6 +199,7 @@ pub struct SolarControlScheduleFsch {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "ValDCSG")]
     pub val_dcsg: ::std::option::Option<SolarCsg>,
 }
 mod solar_control_schedule_fsch {
@@ -219,8 +229,7 @@ impl IsSolarControlScheduleFsch for SolarControlScheduleFsch {
     }
 }
 /// Specialized 61850 FSCC class.  LN: Schedule controller   Name: FSCC
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarControlFscc {
     /// UML inherited base object
     // parent_message: true
@@ -230,9 +239,11 @@ pub struct SolarControlFscc {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlFSCC")]
     pub control_fscc: ::std::option::Option<super::commonmodule::ControlFscc>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "SolarControlScheduleFSCH")]
     pub solar_control_schedule_fsch: ::std::option::Option<SolarControlScheduleFsch>,
 }
 mod solar_control_fscc {
@@ -307,8 +318,7 @@ impl IsIdentifiedObject for SolarControlFscc {
     }
 }
 /// Solar control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarControl {
     /// UML inherited base object
     // parent_message: true
@@ -318,12 +328,15 @@ pub struct SolarControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlValue")]
     pub control_value: ::std::option::Option<super::commonmodule::ControlValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub check: ::std::option::Option<super::commonmodule::CheckConditions>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "solarControlFSCC")]
     pub solar_control_fscc: ::std::option::Option<SolarControlFscc>,
 }
 mod solar_control {
@@ -389,8 +402,7 @@ impl IsIdentifiedObject for SolarControl {
     }
 }
 /// MISSING DOCUMENTATION!!!
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarInverter {
     /// UML inherited base object
     // parent_message: true
@@ -400,6 +412,7 @@ pub struct SolarInverter {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipment")]
     pub conducting_equipment: ::std::option::Option<super::commonmodule::ConductingEquipment>,
 }
 mod solar_inverter {
@@ -452,8 +465,7 @@ impl IsNamedObject for SolarInverter {
 }
 /// Solar control profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarControlProfile {
     /// UML inherited base object
     // parent_message: true
@@ -463,6 +475,7 @@ pub struct SolarControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -472,6 +485,7 @@ pub struct SolarControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "solarControl")]
     pub solar_control: ::std::option::Option<SolarControl>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -481,6 +495,7 @@ pub struct SolarControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "solarInverter")]
     pub solar_inverter: ::std::option::Option<SolarInverter>,
 }
 mod solar_control_profile {
@@ -554,35 +569,43 @@ impl IsIdentifiedObject for SolarControlProfile {
     }
 }
 /// Point definition (Point)
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarPointStatus {
     /// Enable frequency set point
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "frequencySetPointEnabled")]
     pub frequency_set_point_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
     /// Grid connect mode
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub mode: ::std::option::Option<super::commonmodule::EngGridConnectModeKind>,
     /// Black start enable
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "pctHzDroop")]
     pub pct_hz_droop: ::std::option::Option<f32>,
     /// Black start enable
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "pctVDroop")]
     pub pct_v_droop: ::std::option::Option<f32>,
     /// Ramp rates
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "rampRates")]
     pub ramp_rates: ::std::option::Option<super::commonmodule::RampRate>,
     /// Enable reactive power set point
     #[prost(message, optional, tag="6")]
+    #[serde(default, rename = "reactivePwrSetPointEnabled")]
     pub reactive_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
     /// Enable real power set point
     #[prost(message, optional, tag="7")]
+    #[serde(default, rename = "realPwrSetPointEnabled")]
     pub real_pwr_set_point_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
     /// ESS state
     #[prost(message, optional, tag="8")]
+    #[serde(default)]
     pub state: ::std::option::Option<super::commonmodule::OptionalStateKind>,
     /// Enable voltage set point
     #[prost(message, optional, tag="9")]
+    #[serde(default, rename = "voltageSetPointEnabled")]
     pub voltage_set_point_enabled: ::std::option::Option<super::commonmodule::StatusDps>,
 }
 mod solar_point_status {
@@ -668,8 +691,7 @@ impl IsSolarPointStatus for SolarPointStatus {
     }
 }
 /// Specialized 61850 ZGEN class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarEventAndStatusZgen {
     /// UML inherited base object
     // parent_message: true
@@ -679,18 +701,23 @@ pub struct SolarEventAndStatusZgen {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForEventAndStatus")]
     pub logical_node_for_event_and_status: ::std::option::Option<super::commonmodule::LogicalNodeForEventAndStatus>,
     /// DC Power On/Off Status; True = DC power on
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "AuxPwrSt")]
     pub aux_pwr_st: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "DynamicTest")]
     pub dynamic_test: ::std::option::Option<super::commonmodule::EnsDynamicTestKind>,
     /// Emergency stop
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "EmgStop")]
     pub emg_stop: ::std::option::Option<super::commonmodule::StatusSps>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "PointStatus")]
     pub point_status: ::std::option::Option<SolarPointStatus>,
 }
 mod solar_event_and_status_zgen {
@@ -778,8 +805,7 @@ impl IsIdentifiedObject for SolarEventAndStatusZgen {
     }
 }
 /// Specialized 61850 ZGEN class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarEventZgen {
     /// UML inherited base object
     // parent_message: true
@@ -789,9 +815,11 @@ pub struct SolarEventZgen {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "solarEventAndStatusZGEN")]
     pub solar_event_and_status_zgen: ::std::option::Option<SolarEventAndStatusZgen>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "GriMod")]
     pub gri_mod: ::std::option::Option<super::commonmodule::EngGridConnectModeKind>,
 }
 mod solar_event_zgen {
@@ -866,8 +894,7 @@ impl IsIdentifiedObject for SolarEventZgen {
     }
 }
 /// Solar event
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarEvent {
     /// UML inherited base object
     // parent_message: true
@@ -877,9 +904,11 @@ pub struct SolarEvent {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventValue")]
     pub event_value: ::std::option::Option<super::commonmodule::EventValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "solarEventZGEN")]
     pub solar_event_zgen: ::std::option::Option<SolarEventZgen>,
 }
 mod solar_event {
@@ -939,8 +968,7 @@ impl IsIdentifiedObject for SolarEvent {
 }
 /// Solar event profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarEventProfile {
     /// UML inherited base object
     // parent_message: true
@@ -950,6 +978,7 @@ pub struct SolarEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventMessageInfo")]
     pub event_message_info: ::std::option::Option<super::commonmodule::EventMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -959,6 +988,7 @@ pub struct SolarEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "solarEvent")]
     pub solar_event: ::std::option::Option<SolarEvent>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -968,6 +998,7 @@ pub struct SolarEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "solarInverter")]
     pub solar_inverter: ::std::option::Option<SolarInverter>,
 }
 mod solar_event_profile {
@@ -1041,8 +1072,7 @@ impl IsIdentifiedObject for SolarEventProfile {
     }
 }
 /// Solar reading value
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarReading {
     /// UML inherited base object
     // parent_message: true
@@ -1052,15 +1082,19 @@ pub struct SolarReading {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipmentTerminalReading")]
     pub conducting_equipment_terminal_reading: ::std::option::Option<super::commonmodule::ConductingEquipmentTerminalReading>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "phaseMMTN")]
     pub phase_mmtn: ::std::option::Option<super::commonmodule::PhaseMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "readingMMTR")]
     pub reading_mmtr: ::std::option::Option<super::commonmodule::ReadingMmtr>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "readingMMXU")]
     pub reading_mmxu: ::std::option::Option<super::commonmodule::ReadingMmxu>,
 }
 mod solar_reading {
@@ -1126,8 +1160,7 @@ impl IsConductingEquipmentTerminalReading for SolarReading {
 }
 /// Solar reading profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarReadingProfile {
     /// UML inherited base object
     // parent_message: true
@@ -1137,6 +1170,7 @@ pub struct SolarReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "readingMessageInfo")]
     pub reading_message_info: ::std::option::Option<super::commonmodule::ReadingMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1146,6 +1180,7 @@ pub struct SolarReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "solarInverter")]
     pub solar_inverter: ::std::option::Option<SolarInverter>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1155,6 +1190,7 @@ pub struct SolarReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "solarReading")]
     pub solar_reading: ::std::option::Option<SolarReading>,
 }
 mod solar_reading_profile {
@@ -1228,8 +1264,7 @@ impl IsIdentifiedObject for SolarReadingProfile {
     }
 }
 /// Specialized 61850 ZGEN LN class
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarStatusZgen {
     /// UML inherited base object
     // parent_message: true
@@ -1239,9 +1274,11 @@ pub struct SolarStatusZgen {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "solarEventAndStatusZGEN")]
     pub solar_event_and_status_zgen: ::std::option::Option<SolarEventAndStatusZgen>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "GriMod")]
     pub gri_mod: ::std::option::Option<super::commonmodule::EngGridConnectModeKind>,
 }
 mod solar_status_zgen {
@@ -1316,8 +1353,7 @@ impl IsIdentifiedObject for SolarStatusZgen {
     }
 }
 /// Solar status
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarStatus {
     /// UML inherited base object
     // parent_message: true
@@ -1327,9 +1363,11 @@ pub struct SolarStatus {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusValue")]
     pub status_value: ::std::option::Option<super::commonmodule::StatusValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "solarStatusZGEN")]
     pub solar_status_zgen: ::std::option::Option<SolarStatusZgen>,
 }
 mod solar_status {
@@ -1389,8 +1427,7 @@ impl IsIdentifiedObject for SolarStatus {
 }
 /// Solar status profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SolarStatusProfile {
     /// UML inherited base object
     // parent_message: true
@@ -1400,6 +1437,7 @@ pub struct SolarStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusMessageInfo")]
     pub status_message_info: ::std::option::Option<super::commonmodule::StatusMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1409,6 +1447,7 @@ pub struct SolarStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "solarInverter")]
     pub solar_inverter: ::std::option::Option<SolarInverter>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1418,6 +1457,7 @@ pub struct SolarStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "solarStatus")]
     pub solar_status: ::std::option::Option<SolarStatus>,
 }
 mod solar_status_profile {

--- a/openfmb-messages/src/switchmodule.rs
+++ b/openfmb-messages/src/switchmodule.rs
@@ -1,7 +1,6 @@
 use crate::commonmodule::*;
 /// OpenFMB specialization for switch control:  LN: Circuit switch   Name: XSWI
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SwitchDiscreteControlXswi {
     /// UML inherited base object
     // parent_message: true
@@ -11,12 +10,15 @@ pub struct SwitchDiscreteControlXswi {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForControl")]
     pub logical_node_for_control: ::std::option::Option<super::commonmodule::LogicalNodeForControl>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "Pos")]
     pub pos: ::std::option::Option<super::commonmodule::PhaseDpc>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "ResetProtectionPickup")]
     pub reset_protection_pickup: ::std::option::Option<super::commonmodule::ControlSpc>,
 }
 mod switch_discrete_control_xswi {
@@ -90,8 +92,7 @@ impl IsIdentifiedObject for SwitchDiscreteControlXswi {
     }
 }
 /// Switch discrete control
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SwitchDiscreteControl {
     /// UML inherited base object
     // parent_message: true
@@ -101,12 +102,15 @@ pub struct SwitchDiscreteControl {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlValue")]
     pub control_value: ::std::option::Option<super::commonmodule::ControlValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default)]
     pub check: ::std::option::Option<super::commonmodule::CheckConditions>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "switchDiscreteControlXSWI")]
     pub switch_discrete_control_xswi: ::std::option::Option<SwitchDiscreteControlXswi>,
 }
 mod switch_discrete_control {
@@ -172,8 +176,7 @@ impl IsIdentifiedObject for SwitchDiscreteControl {
     }
 }
 /// A ProtectedSwitch is a switching device that can be operated by ProtectionEquipment.
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct ProtectedSwitch {
     /// UML inherited base object
     // parent_message: true
@@ -183,6 +186,7 @@ pub struct ProtectedSwitch {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipment")]
     pub conducting_equipment: ::std::option::Option<super::commonmodule::ConductingEquipment>,
 }
 mod protected_switch {
@@ -235,8 +239,7 @@ impl IsNamedObject for ProtectedSwitch {
 }
 /// Switch control profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SwitchDiscreteControlProfile {
     /// UML inherited base object
     // parent_message: true
@@ -246,6 +249,7 @@ pub struct SwitchDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "controlMessageInfo")]
     pub control_message_info: ::std::option::Option<super::commonmodule::ControlMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -255,6 +259,7 @@ pub struct SwitchDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "protectedSwitch")]
     pub protected_switch: ::std::option::Option<ProtectedSwitch>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -264,6 +269,7 @@ pub struct SwitchDiscreteControlProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "switchDiscreteControl")]
     pub switch_discrete_control: ::std::option::Option<SwitchDiscreteControl>,
 }
 mod switch_discrete_control_profile {
@@ -337,8 +343,7 @@ impl IsIdentifiedObject for SwitchDiscreteControlProfile {
     }
 }
 /// OpenFMB specialization for SwitchEventProfile
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SwitchEventXswi {
     /// UML inherited base object
     // parent_message: true
@@ -348,12 +353,15 @@ pub struct SwitchEventXswi {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForEventAndStatus")]
     pub logical_node_for_event_and_status: ::std::option::Option<super::commonmodule::LogicalNodeForEventAndStatus>,
     /// Dynamic test status
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "DynamicTest")]
     pub dynamic_test: ::std::option::Option<super::commonmodule::EnsDynamicTestKind>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "Pos")]
     pub pos: ::std::option::Option<super::commonmodule::PhaseDps>,
 }
 mod switch_event_xswi {
@@ -427,8 +435,7 @@ impl IsIdentifiedObject for SwitchEventXswi {
     }
 }
 /// Switch event
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SwitchEvent {
     /// UML inherited base object
     // parent_message: true
@@ -438,9 +445,11 @@ pub struct SwitchEvent {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventValue")]
     pub event_value: ::std::option::Option<super::commonmodule::EventValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "switchEventXSWI")]
     pub switch_event_xswi: ::std::option::Option<SwitchEventXswi>,
 }
 mod switch_event {
@@ -500,8 +509,7 @@ impl IsIdentifiedObject for SwitchEvent {
 }
 /// Switch event profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SwitchEventProfile {
     /// UML inherited base object
     // parent_message: true
@@ -511,6 +519,7 @@ pub struct SwitchEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "eventMessageInfo")]
     pub event_message_info: ::std::option::Option<super::commonmodule::EventMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -520,6 +529,7 @@ pub struct SwitchEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "protectedSwitch")]
     pub protected_switch: ::std::option::Option<ProtectedSwitch>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -529,6 +539,7 @@ pub struct SwitchEventProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "switchEvent")]
     pub switch_event: ::std::option::Option<SwitchEvent>,
 }
 mod switch_event_profile {
@@ -602,8 +613,7 @@ impl IsIdentifiedObject for SwitchEventProfile {
     }
 }
 /// Switch reading value
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SwitchReading {
     /// UML inherited base object
     // parent_message: true
@@ -613,18 +623,23 @@ pub struct SwitchReading {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "conductingEquipmentTerminalReading")]
     pub conducting_equipment_terminal_reading: ::std::option::Option<super::commonmodule::ConductingEquipmentTerminalReading>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "diffReadingMMXU")]
     pub diff_reading_mmxu: ::std::option::Option<super::commonmodule::ReadingMmxu>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "phaseMMTN")]
     pub phase_mmtn: ::std::option::Option<super::commonmodule::PhaseMmtn>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "readingMMTR")]
     pub reading_mmtr: ::std::option::Option<super::commonmodule::ReadingMmtr>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "readingMMXU")]
     pub reading_mmxu: ::std::option::Option<super::commonmodule::ReadingMmxu>,
 }
 mod switch_reading {
@@ -697,8 +712,7 @@ impl IsConductingEquipmentTerminalReading for SwitchReading {
 }
 /// Switch reading profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SwitchReadingProfile {
     /// UML inherited base object
     // parent_message: true
@@ -708,6 +722,7 @@ pub struct SwitchReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "readingMessageInfo")]
     pub reading_message_info: ::std::option::Option<super::commonmodule::ReadingMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -717,6 +732,7 @@ pub struct SwitchReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "protectedSwitch")]
     pub protected_switch: ::std::option::Option<ProtectedSwitch>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -726,6 +742,7 @@ pub struct SwitchReadingProfile {
     // uuid: false
     // key: false
     #[prost(message, repeated, tag="3")]
+    #[serde(default, rename = "switchReading")]
     pub switch_reading: ::std::vec::Vec<SwitchReading>,
 }
 mod switch_reading_profile {
@@ -798,8 +815,7 @@ impl IsIdentifiedObject for SwitchReadingProfile {
     }
 }
 /// OpenFMB specialization for SwitchStatusProfile
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SwitchStatusXswi {
     /// UML inherited base object
     // parent_message: true
@@ -809,12 +825,15 @@ pub struct SwitchStatusXswi {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "logicalNodeForEventAndStatus")]
     pub logical_node_for_event_and_status: ::std::option::Option<super::commonmodule::LogicalNodeForEventAndStatus>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "DynamicTest")]
     pub dynamic_test: ::std::option::Option<super::commonmodule::EnsDynamicTestKind>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="4")]
+    #[serde(default, rename = "Pos")]
     pub pos: ::std::option::Option<super::commonmodule::PhaseDps>,
     /// Fault latch: LT01=51A OR 51B OR 51C
     // parent_message: false
@@ -824,6 +843,7 @@ pub struct SwitchStatusXswi {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="5")]
+    #[serde(default, rename = "ProtectionPickup")]
     pub protection_pickup: ::std::option::Option<super::commonmodule::PhaseSps>,
 }
 mod switch_status_xswi {
@@ -904,8 +924,7 @@ impl IsIdentifiedObject for SwitchStatusXswi {
     }
 }
 /// Switch status
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SwitchStatus {
     /// UML inherited base object
     // parent_message: true
@@ -915,9 +934,11 @@ pub struct SwitchStatus {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusValue")]
     pub status_value: ::std::option::Option<super::commonmodule::StatusValue>,
     /// MISSING DOCUMENTATION!!!
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "switchStatusXSWI")]
     pub switch_status_xswi: ::std::option::Option<SwitchStatusXswi>,
 }
 mod switch_status {
@@ -977,8 +998,7 @@ impl IsIdentifiedObject for SwitchStatus {
 }
 /// Switch status profile
 /// OpenFMB Profile Message: true
-#[derive(Clone, PartialEq, ::prost::Message)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, ::prost::Message, serde::Serialize, serde::Deserialize)]
 pub struct SwitchStatusProfile {
     /// UML inherited base object
     // parent_message: true
@@ -988,6 +1008,7 @@ pub struct SwitchStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="1")]
+    #[serde(default, rename = "statusMessageInfo")]
     pub status_message_info: ::std::option::Option<super::commonmodule::StatusMessageInfo>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -997,6 +1018,7 @@ pub struct SwitchStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="2")]
+    #[serde(default, rename = "protectedSwitch")]
     pub protected_switch: ::std::option::Option<ProtectedSwitch>,
     /// MISSING DOCUMENTATION!!!
     // parent_message: false
@@ -1006,6 +1028,7 @@ pub struct SwitchStatusProfile {
     // uuid: false
     // key: false
     #[prost(message, optional, tag="3")]
+    #[serde(default, rename = "switchStatus")]
     pub switch_status: ::std::option::Option<SwitchStatus>,
 }
 mod switch_status_profile {


### PR DESCRIPTION
Uses serde() attributes to set the field names to the protobuf names as well as use the Default::default() like protobufs would when deserializing or serializing with serde