### PR TITLE
OpenFMB profile variant support

### DIFF
--- a/examples/logger.rs
+++ b/examples/logger.rs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2021 Open Energy Solutions Inc
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::StreamExt;
+use log::info;
+use openfmb::{encoding::ProtobufVariantEncoding, messages::ProfileMessage, prelude::*};
+use std::env;
+
+struct OpenFMBEverything {
+    done: bool,
+}
+
+impl Iterator for OpenFMBEverything {
+    type Item = TopicLevel<&'static str>;
+
+    fn next(&mut self) -> Option<TopicLevel<&'static str>> {
+        if !self.done {
+            self.done = true;
+            Some(TopicLevel::Exact("openfmb"))
+        } else {
+            None
+        }
+    }
+}
+
+impl Topic<&'static str> for OpenFMBEverything {
+    fn prefix_match(&self) -> bool {
+        true
+    }
+}
+
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    pretty_env_logger::init();
+    let nats_url = env::var("NATS_URL")?;
+    let nc = nats::asynk::connect(&nats_url).await?;
+    let mut bus = openfmb::bus::NatsBus::<ProtobufVariantEncoding>::new(nc);
+    let openfmb_everything_topic = OpenFMBEverything { done: false };
+    let mut openfmb_stream = bus.subscribe(openfmb_everything_topic).await?;
+    info!(
+        "Connected to OpenFMB Bus and subscribed to all using nats at {:?}",
+        nats_url
+    );
+    while let Some(msg) = openfmb_stream.next().await {
+        let msg: ProfileMessage = msg?;
+        info!("{:?}", msg);
+    }
+    Ok(())
+}

--- a/openfmb-codegen/src/code_generator.rs
+++ b/openfmb-codegen/src/code_generator.rs
@@ -41,6 +41,7 @@ pub struct CodeGenerator<'a> {
     depth: u8,
     path: Vec<i32>,
     buf: &'a mut String,
+    profiles: &'a mut HashSet<String>,
 }
 
 impl<'a> CodeGenerator<'a> {
@@ -51,6 +52,7 @@ impl<'a> CodeGenerator<'a> {
         message_inherits: &MessageInheritance,
         file: FileDescriptorProto,
         buf: &mut String,
+        profiles: &mut HashSet<String>,
     ) {
         let mut source_info = file
             .source_code_info
@@ -80,6 +82,7 @@ impl<'a> CodeGenerator<'a> {
             depth: 0,
             path: Vec::new(),
             buf,
+            profiles,
         };
 
         debug!(
@@ -189,6 +192,10 @@ impl<'a> CodeGenerator<'a> {
         self.append_doc();
         if let Some(message_options) = message.options {
             self.push_indent();
+
+            if message_options.openfmb_profile == Some(true) {
+                self.profiles.insert(String::from(&message_name));
+            }
             let comment = format!(
                 "/// OpenFMB Profile Message: {}\n",
                 message_options.openfmb_profile.unwrap_or(false)

--- a/openfmb-messages/src/lib.rs
+++ b/openfmb-messages/src/lib.rs
@@ -17,3 +17,76 @@ pub mod reservemodule;
 pub mod resourcemodule;
 pub mod solarmodule;
 pub mod switchmodule;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Module {
+    BreakerModule,
+    CapBankModule,
+    CoordinationServiceModule,
+    EssModule,
+    GenerationModule,
+    InterconnectionModule,
+    LoadModule,
+    MeterModule,
+    RecloserModule,
+    RegulatorModule,
+    ReserveModule,
+    ResourceModule,
+    SolarModule,
+    SwitchModule,
+}
+
+impl Module {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Module::BreakerModule => "breakermodule",
+            Module::CapBankModule => "capbankmodule",
+            Module::CoordinationServiceModule => "coordationservicemodule",
+            Module::EssModule => "essmodule",
+            Module::GenerationModule => "generationmodule",
+            Module::LoadModule => "loadmodule",
+            Module::MeterModule => "metermodule",
+            Module::InterconnectionModule => "interconnectionmodule",
+            Module::RecloserModule => "reclosermodule",
+            Module::RegulatorModule => "regulatormodule",
+            Module::ReserveModule => "reservemodule",
+            Module::ResourceModule => "resourcemodule",
+            Module::SolarModule => "solarmodule",
+            Module::SwitchModule => "switchmodule",
+        }
+    }
+}
+
+impl std::fmt::Display for Module {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for Module {
+    type Err = ();
+    fn from_str(input: &str) -> Result<Module, Self::Err> {
+        match input {
+            "breakmodule" => Ok(Module::BreakerModule),
+            "capbankmodule" => Ok(Module::CapBankModule),
+            "coordationservicemodule" => Ok(Module::CoordinationServiceModule),
+            "essmodule" => Ok(Module::EssModule),
+            "generationmodule" => Ok(Module::GenerationModule),
+            "loadmodule" => Ok(Module::LoadModule),
+            "metermodule" => Ok(Module::MeterModule),
+            "interconnectionmodule" => Ok(Module::InterconnectionModule),
+            "reclosermodule" => Ok(Module::RecloserModule),
+            "regulatormodule" => Ok(Module::RegulatorModule),
+            "reservemodule" => Ok(Module::ReserveModule),
+            "resourcemodule" => Ok(Module::ReserveModule),
+            "solarmodule" => Ok(Module::SolarModule),
+            "switchmodule" => Ok(Module::SwitchModule),
+            _ => Err(()),
+        }
+    }
+}
+
+mod profiles;
+pub use profiles::Profile;
+mod variant;
+pub use variant::ProfileMessage;

--- a/openfmb-messages/src/profiles.rs
+++ b/openfmb-messages/src/profiles.rs
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2021 Open Energy Solutions Inc
+//
+// SPDX-License-Identifier: Apache-2.0
+
+include!(concat!(env!("OUT_DIR"), "/profiles.rs"));

--- a/openfmb-messages/src/variant.rs
+++ b/openfmb-messages/src/variant.rs
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2021 Open Energy Solutions Inc
+//
+// SPDX-License-Identifier: Apache-2.0
+
+include!(concat!(env!("OUT_DIR"), "/variant.rs"));

--- a/src/client/switch.rs
+++ b/src/client/switch.rs
@@ -39,7 +39,7 @@ where
 }
 
 fn topic(profile: topic::Profile, mrid: &Uuid) -> ProfileTopic {
-    ProfileTopic::new(topic::Module::Switch, profile, mrid.clone())
+    ProfileTopic::new(Module::SwitchModule, profile, mrid.clone())
 }
 
 impl<MB> Switch<MB>
@@ -54,10 +54,10 @@ where
         Switch {
             bus,
             mrid,
-            status_topic: topic(topic::Profile::Status, &mrid),
-            event_topic: topic(topic::Profile::Event, &mrid),
-            reading_topic: topic(topic::Profile::Reading, &mrid),
-            discrete_control_topic: topic(topic::Profile::DiscreteControl, &mrid),
+            status_topic: topic(Profile::SwitchStatusProfile, &mrid),
+            event_topic: topic(Profile::SwitchEventProfile, &mrid),
+            reading_topic: topic(Profile::SwitchReadingProfile, &mrid),
+            discrete_control_topic: topic(Profile::SwitchDiscreteControlProfile, &mrid),
         }
     }
 

--- a/src/device/switch.rs
+++ b/src/device/switch.rs
@@ -1,9 +1,12 @@
 // SPDX-FileCopyrightText: 2021 Open Energy Solutions Inc //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{prelude::*, topic};
-use openfmb_messages::switchmodule::{
-    SwitchDiscreteControlProfile, SwitchEventProfile, SwitchReadingProfile, SwitchStatusProfile,
+use crate::prelude::*;
+use openfmb_messages::{
+    switchmodule::{
+        SwitchDiscreteControlProfile, SwitchEventProfile, SwitchReadingProfile, SwitchStatusProfile,
+    },
+    Module, Profile,
 };
 use uuid::Uuid;
 
@@ -27,8 +30,8 @@ where
     discrete_control_topic: ProfileTopic,
 }
 
-fn topic(profile: topic::Profile, mrid: &Uuid) -> ProfileTopic {
-    ProfileTopic::new(topic::Module::Switch, profile, mrid.clone())
+fn topic(profile: Profile, mrid: &Uuid) -> ProfileTopic {
+    ProfileTopic::new(Module::SwitchModule, profile, mrid.clone())
 }
 
 impl<MB> Switch<MB>
@@ -45,10 +48,10 @@ where
         Switch {
             bus,
             mrid,
-            status_topic: topic(topic::Profile::Status, &mrid),
-            event_topic: topic(topic::Profile::Event, &mrid),
-            reading_topic: topic(topic::Profile::Reading, &mrid),
-            discrete_control_topic: topic(topic::Profile::DiscreteControl, &mrid),
+            status_topic: topic(Profile::SwitchStatusProfile, &mrid),
+            event_topic: topic(Profile::SwitchEventProfile, &mrid),
+            reading_topic: topic(Profile::SwitchReadingProfile, &mrid),
+            discrete_control_topic: topic(Profile::SwitchDiscreteControlProfile, &mrid),
         }
     }
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -11,4 +11,4 @@ pub trait MessageEncoding: std::fmt::Debug {
 }
 
 mod protobufs;
-pub use protobufs::ProtobufEncoding;
+pub use protobufs::{ProtobufEncoding, ProtobufVariantDecodeError, ProtobufVariantEncoding};

--- a/src/encoding/protobufs.rs
+++ b/src/encoding/protobufs.rs
@@ -4,6 +4,62 @@
 
 use crate::prelude::*;
 use bytes::{Buf, BufMut};
+use std::str::FromStr;
+
+/// Sadly we need a type alias until specialization lands in stable
+/// to do what we really want, which is create another impl Message for the variant ProfileMessage type
+///
+/// So instead this alias is used for the time being. This forces *two* buses to be created if you wish to have type specific
+/// subscribes/publishes or use the variant containing ProfileMessage type
+///
+/// TODO: remove this type alias when specialization lands
+#[derive(Debug, Clone)]
+pub enum ProtobufVariantEncoding {}
+
+#[derive(Debug, Clone)]
+pub enum ProtobufVariantDecodeError {
+    ProstDecodeError(prost::DecodeError),
+    InvalidTopic,
+    InvalidProfile(String),
+}
+
+impl std::fmt::Display for ProtobufVariantDecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for ProtobufVariantDecodeError {}
+
+impl MessageEncoding for ProtobufVariantEncoding {
+    type DecodeError = ProtobufVariantDecodeError;
+    type EncodeError = prost::EncodeError;
+}
+
+/// Protobuf encoding for the ProfileMessage variant enum
+impl Message<ProtobufVariantEncoding> for openfmb_messages::ProfileMessage {
+    fn encode<B: BufMut>(&self, buf: &mut B) -> Result<(), prost::EncodeError> {
+        openfmb_messages::ProfileMessage::encode(self, buf)
+    }
+
+    fn decode<S: AsRef<str>, T: Topic<S>, B: Buf>(
+        mut topic: T,
+        buf: B,
+    ) -> Result<openfmb_messages::ProfileMessage, ProtobufVariantDecodeError> {
+        // maybe decode and validate the topic here into a ProfileTopic instead?
+        let profile = if let Some(last) = topic.nth(2) {
+            match last  {
+                TopicLevel::Exact(profile_str) =>  Profile::from_str(profile_str.as_ref()).map_err(|_err| ProtobufVariantDecodeError::InvalidProfile(format!("{:?}", profile_str.as_ref())))?,
+                TopicLevel::WildCard => return Err(ProtobufVariantDecodeError::InvalidProfile(format!("Wildcard given for last topic level, not convertable to an OpenFMB Profile"))),
+            }
+        } else {
+            // NOTE uses a hidden API here
+            return Err(ProtobufVariantDecodeError::InvalidTopic);
+        };
+        openfmb_messages::ProfileMessage::decode(profile, buf)
+            .map_err(|err| ProtobufVariantDecodeError::ProstDecodeError(err))
+    }
+}
 
 /// ProtobufEncoding (zero sized, non-constructable type)
 #[derive(Debug, Clone)]
@@ -15,7 +71,7 @@ impl MessageEncoding for ProtobufEncoding {
 }
 
 impl<M: prost::Message + Default> Message<ProtobufEncoding> for M {
-    fn encode<B: BufMut>(self: &M, buf: &mut B) -> Result<(), prost::EncodeError> {
+    fn encode<B: BufMut>(&self, buf: &mut B) -> Result<(), prost::EncodeError> {
         M::encode(self, buf)
     }
 
@@ -26,5 +82,3 @@ impl<M: prost::Message + Default> Message<ProtobufEncoding> for M {
         M::decode(buf)
     }
 }
-
-//TODO create an enum with all possible message variants and decode the appropriate variant based on topic


### PR DESCRIPTION
This allows for publishing/subscribing to one or more profile types on a bus. A
provided logger example subscribes to *all* openfmb messages.

This is extremely useful as it allows for run time message type
determination for decoding/encoding rather than compile time.

An example of a logger that requires message variants has been added, it
subscribes to *all* openfmb message types.

Signed-off-by: Tom Burdick <tom@openenergysolutionsinc.com>