### PR TITLE
Refactor capbank client API

### DIFF
--- a/src/client/capbank.rs
+++ b/src/client/capbank.rs
@@ -122,7 +122,7 @@ where
         let mut msg = CapBankControlProfile::capbank_schedule_message(
             &self.mrid_as_string(),
             ScheduleParameterKind::WNetMag,
-            wnet_mag,
+            0_f64,
         );
         msg.cap_bank_control_mut()
             .cap_bank_control_fscc_mut()


### PR DESCRIPTION
The original API used two methods, these methods each sent a number of schedule points for two different types of schedule parameters in a single message each. The refactored API combines both methods into a single method, allowing the client to send a single message whose schedule points contain both schedule parameters.