### PR TITLE
Make `client::capbank::set_power_schedule()` more general.

### DIFF
--- a/src/client/capbank.rs
+++ b/src/client/capbank.rs
@@ -110,59 +110,24 @@ where
             .await?)
     }
 
-    /// Set a `WNetMag` and `VArNetMag` schedule for this capbank device asynchronously
+    /// Publish a set of `SchedulePoint`s to a capbank device.
     ///
     /// Awaits on publishing but no change awaited on
-    pub async fn set_power_schedule(
+    pub async fn schedule(
         &mut self,
-        sch_pts: usize,
-        wnet_mag: f64,
-        varnet_mag: f64,
+        sch_pts: Vec<SchedulePoint>,    
     ) -> PublishResult<()> {
         let mut msg = CapBankControlProfile::capbank_schedule_message(
             &self.mrid_as_string(),
             ScheduleParameterKind::WNetMag,
             0_f64,
         );
-        msg.cap_bank_control_mut()
+        *msg.cap_bank_control_mut()
             .cap_bank_control_fscc_mut()
             .control_fscc_mut()
             .control_schedule_fsch_mut()
             .val_acsg_mut()
-            .sch_pts_mut()
-            .clear();
-
-        for _ in 0..sch_pts {
-            let (seconds, nanoseconds) =
-                match time::SystemTime::now().duration_since(time::SystemTime::UNIX_EPOCH) {
-                    Ok(time) => (time.as_secs(), time.subsec_nanos()),
-                    Err(_) => panic!("SystemTime before UNIX_EPOCH!"),
-                };
-            let ctrl_timestamp = ControlTimestamp {
-                seconds,
-                nanoseconds,
-            };
-            let sch_pt = SchedulePoint {
-                schedule_parameter: vec![
-                    EngScheduleParameter {
-                        schedule_parameter_type: ScheduleParameterKind::WNetMag.into(),
-                        value: wnet_mag,
-                    },
-                    EngScheduleParameter {
-                        schedule_parameter_type: ScheduleParameterKind::VArNetMag.into(),
-                        value: varnet_mag,
-                    },
-                ],
-                start_time: Some(ctrl_timestamp),
-            };
-            msg.cap_bank_control_mut()
-                .cap_bank_control_fscc_mut()
-                .control_fscc_mut()
-                .control_schedule_fsch_mut()
-                .val_acsg_mut()
-                .sch_pts_mut()
-                .push(sch_pt);
-        }
+            .sch_pts_mut() = sch_pts;
         Ok(self.control(msg).await?)
     }
 }

--- a/src/client/capbank.rs
+++ b/src/client/capbank.rs
@@ -113,10 +113,7 @@ where
     /// Publish a set of `SchedulePoint`s to a capbank device.
     ///
     /// Awaits on publishing but no change awaited on
-    pub async fn schedule(
-        &mut self,
-        sch_pts: Vec<SchedulePoint>,    
-    ) -> PublishResult<()> {
+    pub async fn schedule(&mut self, sch_pts: Vec<SchedulePoint>) -> PublishResult<()> {
         let mut msg = CapBankControlProfile::capbank_schedule_message(
             &self.mrid_as_string(),
             ScheduleParameterKind::WNetMag,


### PR DESCRIPTION
Identical to #19; but refactors `client::capbank` instead.