### PR TITLE
Fix warnings

### DIFF
--- a/examples/switch_device.rs
+++ b/examples/switch_device.rs
@@ -6,7 +6,6 @@ use futures::stream::StreamExt;
 use log::info;
 use openfmb::encoding::ProtobufEncoding;
 use openfmb_messages::{commonmodule::*, switchmodule::*};
-use rand::Rng;
 use std::env;
 use std::time::SystemTime;
 use tokio::time;

--- a/src/client/breaker.rs
+++ b/src/client/breaker.rs
@@ -3,13 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{prelude::*, topic};
-use futures::{stream, StreamExt};
-use log::trace;
-use openfmb_messages::{breakermodule::*, commonmodule::*, *};
-use openfmb_messages_ext::breaker::BreakerControlExt;
+use openfmb_messages::breakermodule::*;
 use uuid::Uuid;
-
-use std::time;
 
 pub struct Breaker<MB>
 where
@@ -50,6 +45,7 @@ where
         }
     }
 
+    #[allow(dead_code)]
     fn mrid_as_string(&self) -> String {
         format!("{}", self.mrid.hyphenated())
     }

--- a/src/client/capbank.rs
+++ b/src/client/capbank.rs
@@ -3,23 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{prelude::*, topic};
-use futures::{stream, StreamExt};
-use log::trace;
-use openfmb_messages::{capbankmodule::*, commonmodule::*, *};
-use openfmb_messages_ext::capbank::CapBankControlExt;
+use openfmb_messages::capbankmodule::*;
 use uuid::Uuid;
 
-use std::time;
-
-/// Control and wait on updates from a switch
-///
-/// Every function implies a request for the next future state of the switch
-/// rather than the last seen state. A variant of this interface could possibly
-/// look at the *last* known status and reading instead.
-///
-/// When writing control algorithms however it is easier determine the next
-/// known good value and *then* control it rather than looking at an old status
-/// which may be too old to be useful.
 pub struct CapBank<MB>
 where
     MB: Subscriber<CapBankStatusProfile>
@@ -62,6 +48,7 @@ where
         }
     }
 
+    #[allow(dead_code)]
     fn mrid_as_string(&self) -> String {
         format!("{}", self.mrid.hyphenated())
     }

--- a/src/client/circuitsegment.rs
+++ b/src/client/circuitsegment.rs
@@ -3,13 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{prelude::*, topic};
-use futures::{stream, StreamExt};
-use log::trace;
-use openfmb_messages::{circuitsegmentservicemodule::*, commonmodule::*, *};
-use openfmb_messages_ext::circuitsegmentservice::CircuitSegmentControlExt;
+use openfmb_messages::circuitsegmentservicemodule::*;
 use uuid::Uuid;
-
-use std::time;
 
 pub struct CircuitSegment<MB>
 where
@@ -45,6 +40,7 @@ where
         }
     }
 
+    #[allow(dead_code)]
     fn mrid_as_string(&self) -> String {
         format!("{}", self.mrid.hyphenated())
     }

--- a/src/client/ess.rs
+++ b/src/client/ess.rs
@@ -14,15 +14,6 @@ use openfmb_messages_ext::EssControlExt;
 use std::time::SystemTime;
 use uuid::Uuid;
 
-/// Control and wait on updates from ESS (battery/storage)
-///
-/// Every function implies a request for the next future state of the ess
-/// rather than the last seen state. A variant of this interface could possibly
-/// look at the *last* known status and reading instead.
-///
-/// When writing control algorithms however it is easier determine the next
-/// known good value and *then* control it rather than looking at an old status
-/// which may be too old to be useful.
 pub struct Ess<MB>
 where
     MB: Subscriber<EssStatusProfile>
@@ -62,7 +53,7 @@ where
         }
     }
 
-    /// Get the device MRID as a string
+    #[allow(dead_code)]
     fn mrid_as_string(&self) -> String {
         format!("{}", self.mrid.hyphenated())
     }

--- a/src/client/generation.rs
+++ b/src/client/generation.rs
@@ -3,23 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{prelude::*, topic};
-use futures::{stream, StreamExt};
-
-use openfmb_messages::{commonmodule::*, generationmodule::*};
-
-use openfmb_messages_ext::GenerationControlExt;
-use std::time;
+use openfmb_messages::generationmodule::*;
 use uuid::Uuid;
 
-/// Control and wait on updates from Generation
-///
-/// Every function implies a request for the next future state of the generator
-/// rather than the last seen state. A variant of this interface could possibly
-/// look at the *last* known status and reading instead.
-///
-/// When writing control algorithms however it is easier determine the next
-/// known good value and *then* control it rather than looking at an old status
-/// which may be too old to be useful.
 pub struct Generation<MB>
 where
     MB: Subscriber<GenerationStatusProfile>
@@ -59,7 +45,7 @@ where
         }
     }
 
-    /// Get the device MRID as a string
+    #[allow(dead_code)]
     fn mrid_as_string(&self) -> String {
         format!("{}", self.mrid.hyphenated())
     }

--- a/src/client/load.rs
+++ b/src/client/load.rs
@@ -3,23 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{prelude::*, topic};
-use futures::{stream, StreamExt};
-use log::trace;
-use openfmb_messages::{commonmodule::*, loadmodule::*, *};
-use openfmb_messages_ext::load::LoadControlExt;
+use openfmb_messages::loadmodule::*;
 use uuid::Uuid;
 
-use std::time;
-
-/// Control and wait on updates from a load
-///
-/// Every function implies a request for the next future state of the switch
-/// rather than the last seen state. A variant of this interface could possibly
-/// look at the *last* known status and reading instead.
-///
-/// When writing control algorithms however it is easier determine the next
-/// known good value and *then* control it rather than looking at an old status
-/// which may be too old to be useful.
 pub struct Load<MB>
 where
     MB: Subscriber<LoadStatusProfile>
@@ -58,6 +44,7 @@ where
         }
     }
 
+    #[allow(dead_code)]
     fn mrid_as_string(&self) -> String {
         format!("{}", self.mrid.hyphenated())
     }

--- a/src/client/recloser.rs
+++ b/src/client/recloser.rs
@@ -3,13 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{prelude::*, topic};
-use futures::{stream, StreamExt};
-use log::trace;
-use openfmb_messages::{commonmodule::*, reclosermodule::*, *};
-use openfmb_messages_ext::recloser::RecloserControlExt;
+use openfmb_messages::reclosermodule::*;
 use uuid::Uuid;
-
-use std::time;
 
 pub struct Recloser<MB>
 where
@@ -49,6 +44,7 @@ where
         }
     }
 
+    #[allow(dead_code)]
     fn mrid_as_string(&self) -> String {
         format!("{}", self.mrid.hyphenated())
     }

--- a/src/client/regulator.rs
+++ b/src/client/regulator.rs
@@ -3,23 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{prelude::*, topic};
-use futures::{stream, StreamExt};
-use log::trace;
-use openfmb_messages::{commonmodule::*, regulatormodule::*, *};
-use openfmb_messages_ext::regulator::RegulatorControlExt;
+use openfmb_messages::regulatormodule::*;
 use uuid::Uuid;
 
-use std::time;
-
-/// Control and wait on updates from a switch
-///
-/// Every function implies a request for the next future state of the switch
-/// rather than the last seen state. A variant of this interface could possibly
-/// look at the *last* known status and reading instead.
-///
-/// When writing control algorithms however it is easier determine the next
-/// known good value and *then* control it rather than looking at an old status
-/// which may be too old to be useful.
 pub struct Regulator<MB>
 where
     MB: Subscriber<RegulatorStatusProfile>
@@ -62,6 +48,7 @@ where
         }
     }
 
+    #[allow(dead_code)]
     fn mrid_as_string(&self) -> String {
         format!("{}", self.mrid.hyphenated())
     }

--- a/src/client/resource.rs
+++ b/src/client/resource.rs
@@ -3,13 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{prelude::*, topic};
-use futures::{stream, StreamExt};
-use log::trace;
-use openfmb_messages::{commonmodule::*, resourcemodule::*, *};
-use openfmb_messages_ext::resource::ResourceControlExt;
+use openfmb_messages::resourcemodule::*;
 use uuid::Uuid;
-
-use std::time;
 
 pub struct Resource<MB>
 where
@@ -49,6 +44,7 @@ where
         }
     }
 
+    #[allow(dead_code)]
     fn mrid_as_string(&self) -> String {
         format!("{}", self.mrid.hyphenated())
     }

--- a/src/client/solar.rs
+++ b/src/client/solar.rs
@@ -2,21 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::prelude::*;
-use openfmb_messages::{commonmodule::*, solarmodule::*, Module, Profile};
-use openfmb_messages_ext::solar::SolarControlExt;
-
+use openfmb_messages::{solarmodule::*, Module, Profile};
 use uuid::Uuid;
 
-use std::time;
-
-/// Provide functionality to publish and accept messages a switch device
-/// needs.
-#[derive(Debug, Clone)]
 pub struct Solar<MB>
 where
-    MB: std::fmt::Debug
-        + Clone
-        + Subscriber<SolarStatusProfile>
+    MB: Subscriber<SolarStatusProfile>
         + Subscriber<SolarEventProfile>
         + Subscriber<SolarReadingProfile>
         + Publisher<SolarControlProfile>,
@@ -35,9 +26,7 @@ fn topic(profile: Profile, mrid: &Uuid) -> ProfileTopic {
 
 impl<MB> Solar<MB>
 where
-    MB: std::fmt::Debug
-        + Clone
-        + Subscriber<SolarStatusProfile>
+    MB: Subscriber<SolarStatusProfile>
         + Subscriber<SolarEventProfile>
         + Subscriber<SolarReadingProfile>
         + Publisher<SolarControlProfile>,
@@ -54,6 +43,7 @@ where
         }
     }
 
+    #[allow(dead_code)]
     fn mrid_as_string(&self) -> String {
         format!("{}", self.mrid.hyphenated())
     }

--- a/src/device/breaker.rs
+++ b/src/device/breaker.rs
@@ -22,7 +22,7 @@ where
         + Subscriber<BreakerDiscreteControlProfile>,
 {
     bus: MB,
-    mrid: Uuid,
+    _mrid: Uuid,
     status_topic: ProfileTopic,
     event_topic: ProfileTopic,
     reading_topic: ProfileTopic,
@@ -46,7 +46,7 @@ where
     pub fn new(bus: MB, mrid: Uuid) -> Breaker<MB> {
         Breaker {
             bus,
-            mrid,
+            _mrid: mrid,
             status_topic: topic(Profile::BreakerStatusProfile, &mrid),
             event_topic: topic(Profile::BreakerEventProfile, &mrid),
             reading_topic: topic(Profile::BreakerReadingProfile, &mrid),

--- a/src/device/capbank.rs
+++ b/src/device/capbank.rs
@@ -11,8 +11,6 @@ use openfmb_messages::{
 };
 use uuid::Uuid;
 
-/// Provide functionality to publish and accept messages a capbank device
-/// needs.
 #[derive(Debug, Clone)]
 pub struct CapBank<MB>
 where
@@ -25,7 +23,7 @@ where
         + Subscriber<CapBankDiscreteControlProfile>,
 {
     bus: MB,
-    mrid: Uuid,
+    _mrid: Uuid,
     status_topic: ProfileTopic,
     event_topic: ProfileTopic,
     reading_topic: ProfileTopic,
@@ -51,7 +49,7 @@ where
     pub fn new(bus: MB, mrid: Uuid) -> CapBank<MB> {
         CapBank {
             bus,
-            mrid,
+            _mrid: mrid,
             status_topic: topic(Profile::CapBankStatusProfile, &mrid),
             event_topic: topic(Profile::CapBankEventProfile, &mrid),
             reading_topic: topic(Profile::CapBankReadingProfile, &mrid),

--- a/src/device/circuitsegment.rs
+++ b/src/device/circuitsegment.rs
@@ -20,7 +20,7 @@ where
         + Subscriber<CircuitSegmentControlProfile>,
 {
     bus: MB,
-    mrid: Uuid,
+    _mrid: Uuid,
     status_topic: ProfileTopic,
     event_topic: ProfileTopic,
     control_topic: ProfileTopic,
@@ -41,7 +41,7 @@ where
     pub fn new(bus: MB, mrid: Uuid) -> CircuitSegment<MB> {
         CircuitSegment {
             bus,
-            mrid,
+            _mrid: mrid,
             status_topic: topic(Profile::CircuitSegmentStatusProfile, &mrid),
             event_topic: topic(Profile::CircuitSegmentEventProfile, &mrid),
             control_topic: topic(Profile::CircuitSegmentControlProfile, &mrid),

--- a/src/device/ess.rs
+++ b/src/device/ess.rs
@@ -9,8 +9,6 @@ use openfmb_messages::{
 
 use uuid::Uuid;
 
-/// Provide functionality to publish and accept messages a switch device
-/// needs.
 #[derive(Debug, Clone)]
 pub struct Ess<MB>
 where
@@ -22,7 +20,7 @@ where
         + Subscriber<EssControlProfile>,
 {
     bus: MB,
-    mrid: Uuid,
+    _mrid: Uuid,
     status_topic: ProfileTopic,
     event_topic: ProfileTopic,
     reading_topic: ProfileTopic,
@@ -46,7 +44,7 @@ where
     pub fn new(bus: MB, mrid: Uuid) -> Ess<MB> {
         Ess {
             bus,
-            mrid,
+            _mrid: mrid,
             status_topic: topic(Profile::ESSStatusProfile, &mrid),
             event_topic: topic(Profile::ESSEventProfile, &mrid),
             reading_topic: topic(Profile::ESSReadingProfile, &mrid),

--- a/src/device/generation.rs
+++ b/src/device/generation.rs
@@ -12,8 +12,6 @@ use openfmb_messages::{
 
 use uuid::Uuid;
 
-/// Provide functionality to publish and accept messages a switch device
-/// needs.
 #[derive(Debug, Clone)]
 pub struct Generation<MB>
 where
@@ -25,7 +23,7 @@ where
         + Subscriber<GenerationControlProfile>,
 {
     bus: MB,
-    mrid: Uuid,
+    _mrid: Uuid,
     status_topic: ProfileTopic,
     event_topic: ProfileTopic,
     reading_topic: ProfileTopic,
@@ -49,7 +47,7 @@ where
     pub fn new(bus: MB, mrid: Uuid) -> Generation<MB> {
         Generation {
             bus,
-            mrid,
+            _mrid: mrid,
             status_topic: topic(Profile::GenerationStatusProfile, &mrid),
             event_topic: topic(Profile::GenerationEventProfile, &mrid),
             reading_topic: topic(Profile::GenerationReadingProfile, &mrid),

--- a/src/device/load.rs
+++ b/src/device/load.rs
@@ -19,7 +19,7 @@ where
         + Subscriber<LoadControlProfile>,
 {
     bus: MB,
-    mrid: Uuid,
+    _mrid: Uuid,
     status_topic: ProfileTopic,
     event_topic: ProfileTopic,
     reading_topic: ProfileTopic,
@@ -43,7 +43,7 @@ where
     pub fn new(bus: MB, mrid: Uuid) -> Load<MB> {
         Load {
             bus,
-            mrid,
+            _mrid: mrid,
             status_topic: topic(Profile::LoadStatusProfile, &mrid),
             event_topic: topic(Profile::LoadEventProfile, &mrid),
             reading_topic: topic(Profile::LoadReadingProfile, &mrid),

--- a/src/device/recloser.rs
+++ b/src/device/recloser.rs
@@ -22,7 +22,7 @@ where
         + Subscriber<RecloserDiscreteControlProfile>,
 {
     bus: MB,
-    mrid: Uuid,
+    _mrid: Uuid,
     status_topic: ProfileTopic,
     event_topic: ProfileTopic,
     reading_topic: ProfileTopic,
@@ -46,7 +46,7 @@ where
     pub fn new(bus: MB, mrid: Uuid) -> Recloser<MB> {
         Recloser {
             bus,
-            mrid,
+            _mrid: mrid,
             status_topic: topic(Profile::RecloserStatusProfile, &mrid),
             event_topic: topic(Profile::RecloserEventProfile, &mrid),
             reading_topic: topic(Profile::RecloserReadingProfile, &mrid),

--- a/src/device/regulator.rs
+++ b/src/device/regulator.rs
@@ -11,8 +11,6 @@ use openfmb_messages::{
 };
 use uuid::Uuid;
 
-/// Provide functionality to publish and accept messages a regulator device
-/// needs.
 #[derive(Debug, Clone)]
 pub struct Regulator<MB>
 where
@@ -25,7 +23,7 @@ where
         + Subscriber<RegulatorDiscreteControlProfile>,
 {
     bus: MB,
-    mrid: Uuid,
+    _mrid: Uuid,
     status_topic: ProfileTopic,
     event_topic: ProfileTopic,
     reading_topic: ProfileTopic,
@@ -51,7 +49,7 @@ where
     pub fn new(bus: MB, mrid: Uuid) -> Regulator<MB> {
         Regulator {
             bus,
-            mrid,
+            _mrid: mrid,
             status_topic: topic(Profile::RegulatorStatusProfile, &mrid),
             event_topic: topic(Profile::RegulatorEventProfile, &mrid),
             reading_topic: topic(Profile::RegulatorReadingProfile, &mrid),

--- a/src/device/resource.rs
+++ b/src/device/resource.rs
@@ -22,7 +22,7 @@ where
         + Subscriber<ResourceDiscreteControlProfile>,
 {
     bus: MB,
-    mrid: Uuid,
+    _mrid: Uuid,
     status_topic: ProfileTopic,
     event_topic: ProfileTopic,
     reading_topic: ProfileTopic,
@@ -46,7 +46,7 @@ where
     pub fn new(bus: MB, mrid: Uuid) -> Resource<MB> {
         Resource {
             bus,
-            mrid,
+            _mrid: mrid,
             status_topic: topic(Profile::ResourceStatusProfile, &mrid),
             event_topic: topic(Profile::ResourceEventProfile, &mrid),
             reading_topic: topic(Profile::ResourceReadingProfile, &mrid),

--- a/src/device/solar.rs
+++ b/src/device/solar.rs
@@ -11,8 +11,6 @@ use openfmb_messages::{
 
 use uuid::Uuid;
 
-/// Provide functionality to publish and accept messages a switch device
-/// needs.
 #[derive(Debug, Clone)]
 pub struct Solar<MB>
 where
@@ -24,7 +22,7 @@ where
         + Subscriber<SolarControlProfile>,
 {
     bus: MB,
-    mrid: Uuid,
+    _mrid: Uuid,
     status_topic: ProfileTopic,
     event_topic: ProfileTopic,
     reading_topic: ProfileTopic,
@@ -48,7 +46,7 @@ where
     pub fn new(bus: MB, mrid: Uuid) -> Solar<MB> {
         Solar {
             bus,
-            mrid,
+            _mrid: mrid,
             status_topic: topic(Profile::SolarStatusProfile, &mrid),
             event_topic: topic(Profile::SolarEventProfile, &mrid),
             reading_topic: topic(Profile::SolarReadingProfile, &mrid),

--- a/src/device/switch.rs
+++ b/src/device/switch.rs
@@ -10,8 +10,6 @@ use openfmb_messages::{
 };
 use uuid::Uuid;
 
-/// Provide functionality to publish and accept messages a switch device
-/// needs.
 #[derive(Debug, Clone)]
 pub struct Switch<MB>
 where


### PR DESCRIPTION
- Removes unused dependencies in `src/client`, and `examples`; as well as somewhat redundant comments
- Indicate `src/device` data structures' mrid field is unread via `_` prefix
- Include `#[allow(dead_code]` attribute for private helper function `mrid_as_string()`